### PR TITLE
[Task] Sync Sprint 3 documentation and JSON storage strategy

### DIFF
--- a/Function_Details.md
+++ b/Function_Details.md
@@ -1,11 +1,13 @@
-# Functional Specification: Sprint 1 and Sprint 2
+# Functional Specification: Sprint 1, Sprint 2 and Sprint 3
 
 ## 1. Introduction
-This document specifies the detailed functional requirements for Sprint 1 and Sprint 2 of the BUPT International School TA Recruitment System.
+This document specifies the detailed functional requirements for Sprint 1, Sprint 2 and Sprint 3 of the BUPT International School TA Recruitment System.
 
 Sprint 1 focuses on the core recruitment foundation, including authentication, applicant profile management, and the basic Module Organiser recruitment workflow.
 
 Sprint 2 extends the system with administrator-side management and the advanced Module Organiser operational workflow built on top of the Sprint 1 foundation.
+
+Sprint 3 focuses on workflow optimization, reporting, self-service account maintenance, historical visibility, and non-functional improvement for final product delivery.
 
 ## 2. Sprint 1 Detailed Feature Specifications
 
@@ -429,3 +431,320 @@ This provides the shared admin-side control layer for Sprint 2. In this iteratio
 
 **Assignee:** Tianzi Xiong / Fangyu Chu  
 **Completion Date:** 2026-04-11
+
+---
+
+## 4. Sprint 3 Detailed Feature Specifications
+
+### 4.1 Feature: Administrator Sprint 3 Monitoring and Reporting Extension
+
+**User Stories:**
+- **ADM_04:** As an Admin, I want to compare each TA's actual workload with a configurable maximum threshold and mark overloaded TAs with a warning label, so that I can identify risk cases immediately.
+- **ADM_05:** As an Admin, I want to generate and export a weekly recruitment summary report, so that I can report hiring progress to school management.
+- **ADM_07:** As an Admin, I want to filter jobs by department or status, so that I can review targeted vacancy groups more efficiently.
+
+**Description:**
+This Sprint 3 administrator extension improves operational visibility and reporting on top of the Sprint 2 dashboard foundation.
+
+The scope of this iteration contains three connected capabilities:
+
+1. **Configurable workload warning control**
+   - define and save a global weekly workload threshold;
+   - compare hired workload totals against the threshold in real time;
+   - highlight overloaded TAs clearly in the workload view.
+
+2. **Recruitment summary reporting**
+   - generate weekly summary output from current jobs and hiring data;
+   - export report content in plain-text-compatible file formats;
+   - support management-facing recruitment progress review.
+
+3. **Focused job filtering**
+   - filter job records by department and recruitment status;
+   - narrow dashboard tables/cards to a target subset;
+   - make large job lists easier to manage during final delivery.
+
+**Acceptance Criteria:**
+1. The admin can define a global workload threshold value and save it persistently.
+2. The workload page compares each TA's current weekly hours against the saved threshold.
+3. TAs whose workload exceeds the threshold are marked with a visible warning label.
+4. The admin can trigger export of a weekly recruitment report in `.txt` or `.csv` format.
+5. The exported report includes job title, organiser, hiring status, filled slots, and unfilled slots.
+6. The admin can filter job records by department and status without reloading the whole page manually.
+7. Filter results refresh both summary and detailed job views consistently.
+
+**Functional Requirement Details:**
+
+- **Servlet Implementation (new/extended):**
+  - `AdminWorkloadSettingsServlet` (`GET/POST /api/admin/settings/workload-threshold`) for loading and saving the global workload threshold.
+  - `AdminRecruitmentReportExportServlet` (`GET /api/admin/reports/weekly`) for generating downloadable weekly recruitment summaries.
+  - `AdminDashboardServlet` (`GET /api/admin/dashboard`) extended to support optional filter parameters such as `department` and `status`.
+
+- **Service Layer (new/extended):**
+  - `AdminDashboardService`:
+    - load dashboard data with filter-aware job aggregation;
+    - compare workload totals against the configured threshold;
+    - map workload records into normal / warning states.
+  - `AdminReportService`:
+    - collect weekly recruitment statistics;
+    - format export content as text or CSV;
+    - ensure exported output stays compatible with file-based submission rules.
+
+- **Data Management:**
+  - `applications.json` and `jobs.json` remain the primary source for workload and hiring statistics.
+  - A new lightweight settings file such as `system_settings.json` stores the workload threshold persistently.
+  - Exported report files are generated from current runtime data and do not require database support.
+  - Department metadata, when used for filtering, must be stored in the job record structure consistently.
+
+- **Frontend Integration:**
+  - `admin.jsp` adds:
+    - threshold setting input;
+    - report export entry;
+    - job filter controls.
+  - `admin.js` adds:
+    - threshold save/load interaction;
+    - filter-driven dashboard refresh;
+    - export trigger and success/failure feedback.
+
+- **Validation / Business Rules:**
+  - The workload threshold must be a positive numeric value.
+  - Export requests must only include jobs and hiring records visible to administrators.
+  - Filter values must be validated against supported department and status options.
+  - Empty filter results must still return a successful response with an empty dataset.
+
+- **Session / Access Control:**
+  - All `/api/admin/*` routes remain admin-only.
+  - Non-admin users must not be able to read or modify threshold settings or export reports.
+
+**Assignee:**
+**Completion Date:**
+
+---
+
+### 4.2 Feature: User Self-Service Password Change System
+
+**User Stories:**
+- **ALL_03:** As a user, I want to change my password, so that I can keep my account secure without relying on an administrator.
+
+**Description:**
+This Sprint 3 shared feature adds self-service credential maintenance for authenticated users.
+
+The feature allows users from different roles to update their own password through a common account endpoint while preserving current session-based access control. It complements the administrator reset capability from Sprint 2 by adding a normal user-owned password management flow.
+
+**Acceptance Criteria:**
+1. An authenticated user can submit their current password and a new password.
+2. The system validates the current password before making any change.
+3. The new password is written back to `users.json` successfully.
+4. The user receives a clear success or failure message after submission.
+5. Invalid old passwords are rejected without changing stored credentials.
+
+**Functional Requirement Details:**
+
+- **Servlet Implementation (new):**
+  - `ChangePasswordServlet` (`POST /api/account/change-password`) for authenticated self-service password updates.
+
+- **Service Layer (new):**
+  - `AccountService`:
+    - verify current user identity from session;
+    - validate old password;
+    - apply the password update to the matching user record.
+
+- **Data Management:**
+  - `users.json` remains the source of truth for credential records.
+  - Password changes update the current user's existing record only.
+  - No extra persistence file is required for this feature.
+
+- **Frontend Integration:**
+  - Each role portal may expose a common account settings entry or inline password-change form.
+  - Shared frontend logic should submit old/new password values to the common account API and show validation feedback.
+
+- **Validation / Business Rules:**
+  - `oldPassword`, `newPassword`, and confirmation input are required.
+  - The new password must be different from the old password.
+  - Blank or invalid password changes must be rejected with a specific error message.
+
+- **Session / Access Control:**
+  - Only authenticated users can call `/api/account/change-password`.
+  - Users can only change their own password and cannot modify another account through this endpoint.
+
+**Assignee:**
+**Completion Date:**
+
+---
+
+### 4.3 Feature: Performance and Loading Experience Enhancement
+
+**User Stories:**
+- **NFR_01:** As a stakeholder, I want the system to load file-based data quickly and provide loading feedback, so that users do not experience noticeable lag during normal operation.
+
+**Description:**
+This Sprint 3 non-functional feature improves system responsiveness and user feedback for file-based workflows.
+
+The goal is to keep the application usable under realistic project data volume while making loading, refresh, and export operations visibly understandable to users. The improvement should support the final demonstration, testing tasks, and day-to-day use of the file-based architecture.
+
+**Acceptance Criteria:**
+1. Normal dashboard and list-loading operations complete within an acceptable short delay under demonstration-scale data volume.
+2. Long-running file reads or exports show a clear loading or progress state on the frontend.
+3. Large or empty datasets do not cause the interface to freeze or become unresponsive.
+4. Performance-related improvements are documented and can be demonstrated during final delivery.
+
+**Functional Requirement Details:**
+
+- **Backend Optimization Scope:**
+  - reduce repeated file reads where safe within a single request flow;
+  - keep JSON parsing and response mapping simple and predictable;
+  - avoid unnecessary duplicate aggregation passes on jobs, users, and applications.
+
+- **Frontend Integration:**
+  - key pages such as `student.jsp`, `teacher.jsp`, `mo-applications.jsp`, and `admin.jsp` must display loading, empty, and error states clearly.
+  - export and report actions must show in-progress feedback until the operation completes.
+  - periodic refresh logic must avoid disruptive re-rendering of user-expanded content where possible.
+
+- **Testing / Verification:**
+  - manual response-time checks should be performed for login, dashboard loading, job browsing, application listing, and export flows.
+  - regression checks should confirm that optimization changes do not alter business logic or access control.
+  - test evidence should be recorded for the final report and demonstration preparation.
+
+- **Data Management:**
+  - optimization must remain compatible with the required plain-text / JSON persistence approach.
+  - no database, cache server, or heavyweight framework dependency may be introduced.
+
+**Assignee:**
+**Completion Date:**
+
+---
+
+### 4.4 Feature: Module Organiser Sprint 3 Productivity and Review Enhancement
+
+**User Stories:**
+- **MO_05:** As a Module Organiser (MO), I want to mark applicants as shortlisted, rejected, or pending and add evaluation notes, so that I can track review decisions consistently.
+- **MO_08:** As a Module Organiser (MO), I want to view a history list of all posted TA jobs, so that I can trace past recruitment and reuse job information later.
+- **MO_09:** As a Module Organiser (MO), I want to export my applicant list as a CSV/JSON file, so that I can review candidate information offline.
+
+**Description:**
+This Sprint 3 MO feature set focuses on review productivity, historical visibility, and offline analysis support.
+
+The scope of this iteration contains three coordinated parts:
+
+1. **Application review enhancement**
+   - support richer review-state management;
+   - store organiser-side evaluation notes;
+   - allow status-based filtering and batch-oriented review workflow.
+
+2. **Posted job history**
+   - show current and past job records in a unified history view;
+   - expose status, applicant count, hire count, publish time, and deadline;
+   - support quick reuse of historical job information for future recruitment cycles.
+
+3. **Applicant data export**
+   - export current or filtered applicant lists;
+   - support plain-text-compatible output formats such as CSV / JSON;
+   - improve offline review and evidence preparation.
+
+**Acceptance Criteria:**
+1. The MO can mark applicant status as shortlisted, rejected, or pending/viewed through the application page.
+2. The MO can save a private evaluation note for each applicant, and the note persists after refresh.
+3. The application list can be filtered by review status.
+4. The MO can open a history list of posted jobs sorted by release time and see summary metadata for each job.
+5. The MO can open historical job details and review related applicant/hiring summary data.
+6. The MO can export all applicants or a filtered subset in CSV or JSON format.
+7. Exported files include applicant name, applicant ID, major/programme, application time, status, and skills.
+
+**Functional Requirement Details:**
+
+- **Servlet Implementation (new/extended):**
+  - `MoApplicationStatusServlet` (`POST /api/mo/applications/status`) extended to support note persistence and batch review operations.
+  - `MoJobHistoryServlet` (`GET /api/mo/jobs/history`) for posted-job history list and summary retrieval.
+  - `MoApplicantExportServlet` (`GET /api/mo/applications/export`) for CSV / JSON export generation.
+
+- **Service Layer (new/extended):**
+  - `MoApplicationService`:
+    - persist organiser-side review notes;
+    - filter and group application records by status;
+    - support consistent review-state updates.
+  - `MoJobService`:
+    - provide history-oriented job summaries;
+    - prepare reusable job metadata for future reposting.
+  - `MoExportService`:
+    - transform visible applicant data into downloadable CSV / JSON output;
+    - keep export content aligned with current MO ownership rules.
+
+- **Data Management:**
+  - `applications.json` is extended to store MO-side evaluation note fields and review timestamps where needed.
+  - `jobs.json` remains the source of truth for current and historical job metadata.
+  - Exported files are generated dynamically and do not replace source JSON data.
+
+- **Frontend Integration:**
+  - `mo-applications.jsp` + `mo-applications.js` add:
+    - status filter controls;
+    - note entry / autosave or save action;
+    - export trigger for current applicant scope.
+  - `teacher.jsp` + `teacher.js` or a dedicated history page add:
+    - posted-job history list;
+    - job summary view;
+    - quick reuse / copy entry for historical jobs.
+
+- **Validation / Business Rules:**
+  - Evaluation notes are organiser-visible and admin-visible only; they are not shown to applicants.
+  - Export results must include only jobs owned by the current MO.
+  - Batch review actions must preserve ownership checks and recruitment-closed rules.
+  - Historical records must remain readable even after recruitment is closed.
+
+- **Session / Access Control:**
+  - All `/api/mo/*` endpoints require authenticated MO identity.
+  - MOs can only review, export, and access history for their own jobs and applications.
+
+**Assignee:**
+**Completion Date:**
+
+---
+
+### 4.5 Feature: Applicant Sprint 3 Assignment and Schedule Visibility
+
+**User Stories:**
+- **TA_12:** As an Applicant (TA), I want to view my assigned TA jobs and schedule, so that I can understand workload and avoid conflicts with my classes.
+
+**Description:**
+This Sprint 3 applicant feature extends the student-side workflow beyond application tracking into post-hiring visibility.
+
+The feature provides a dedicated view of accepted jobs, associated schedule information, and workload-related summary so that hired students can understand their confirmed commitments clearly after recruitment decisions are finalized.
+
+**Acceptance Criteria:**
+1. Accepted jobs are displayed in a dedicated applicant-side view.
+2. Each accepted job shows key schedule/workload information such as module, organiser, weekly hours, and time arrangement.
+3. Only applications with a final accepted/hired state appear in the assigned-jobs view.
+4. The assigned-jobs page updates correctly after hiring results change.
+
+**Functional Requirement Details:**
+
+- **Servlet Implementation (new/extended):**
+  - `StudentAssignedJobsServlet` (`GET /api/student/my-jobs`) for retrieving hired job assignments and schedule-related data.
+  - `StudentApplicationsServlet` may be extended to expose a clearer separation between active applications and accepted assignments if needed.
+
+- **Service Layer (new/extended):**
+  - `StudentService`:
+    - collect applications whose status is `hired`;
+    - join hired application records with corresponding job metadata;
+    - map schedule, module, organiser, and weekly-hour information into a student-facing response.
+
+- **Data Management:**
+  - `applications.json` provides the hiring outcome through final application status.
+  - `jobs.json` provides module, organiser, workload, and schedule/time-slot information for assigned jobs.
+  - Schedule-related fields must remain consistent across job posting and assigned-job display.
+
+- **Frontend Integration:**
+  - `student.jsp` + `student.js` add a dedicated assigned-jobs or schedule panel.
+  - The applicant UI should distinguish clearly between:
+    - active applications still under review;
+    - confirmed TA assignments already accepted.
+
+- **Validation / Business Rules:**
+  - Only final hired assignments are shown in the assigned-jobs view.
+  - Withdrawn, rejected, or pending applications must not appear in the assigned-jobs list.
+  - If no hired jobs exist, the UI should show a clear empty state instead of a broken table or panel.
+
+- **Session / Access Control:**
+  - All `/api/student/*` routes require authenticated student identity.
+  - Students can only view their own assigned jobs and schedule data.
+
+**Assignee:**
+**Completion Date:**

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Use the following accounts for demonstration:
 ## Current Version Notes
 
 - Sprint 1 release tag: `v1.0-sprint1`
-- Current repository state includes Sprint 2 intermediate development on top of the Sprint 1 foundation
+- Current repository state is `Sprint 3 development in progress`
+- Sprint 1 and Sprint 2 core workflows are already implemented and remain the current functional baseline
+- Sprint 3 work now focuses on workflow optimization, JSON data design, reporting, and final acceptance preparation
 
 ## Current Features
 
@@ -65,6 +67,50 @@ Use the following accounts for demonstration:
 - Student workflow for profile management, supporting document upload, job browsing, application submission, and application tracking
 - MO workflow for demand creation, approval tracking, job publishing, applicant review, hiring actions, and recruitment lifecycle control
 - Admin workflow for dashboard overview, workload monitoring, demand review, recruitment reopen, and user management
+
+## Sprint 3 Focus
+
+- Admin: workload threshold setting, weekly report export, and job filtering
+- Shared: self-service password change
+- MO: applicant review notes, posted-job history, and applicant export
+- TA: assigned jobs and schedule visibility
+- Non-functional: performance, loading-state polish, and acceptance-test preparation
+
+## Runtime Data Storage
+
+The application uses a single JSON-file storage location under `web/src/main/webapp/WEB-INF/data`.
+
+- Source of truth:
+  - `web/src/main/webapp/WEB-INF/data/users.json`
+  - `web/src/main/webapp/WEB-INF/data/students.json`
+  - `web/src/main/webapp/WEB-INF/data/jobs.json`
+  - `web/src/main/webapp/WEB-INF/data/applications.json`
+  - `web/src/main/webapp/WEB-INF/data/notifications.json`
+  - `web/src/main/webapp/WEB-INF/data/hiring_history.json`
+  - `web/src/main/webapp/WEB-INF/data/system_settings.json`
+- The backend reads and writes these files directly through `JsonUtility`.
+- No external runtime copy and no database are used.
+
+Initialization rules:
+
+- Existing files under `WEB-INF/data` are used directly.
+- If a required JSON file is missing, the application creates it automatically.
+- List-based files are initialized as `[]`.
+- `system_settings.json` is initialized as:
+
+```json
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "ISO-8601"
+}
+```
+
+- To reset demo data, edit or restore the files under `web/src/main/webapp/WEB-INF/data` directly.
+
+## Project Docs
+
+- Sprint 3 minimal interface and data design: [docs/Sprint3_Minimal_Design.md](docs/Sprint3_Minimal_Design.md)
+- Acceptance checklist for hand test and demo rehearsal: [docs/Acceptance_Test_Checklist.md](docs/Acceptance_Test_Checklist.md)
 
 ## 1. Project Introduction 
 ### Project Overview
@@ -87,6 +133,15 @@ The current intermediate version includes:
 - administrator user creation, deletion, and password reset
 - expanded MO workflow for applicant review, hiring decisions, and job lifecycle control
 - expanded student workflow for profile persistence, attachments, and application management
+
+### Sprint 3 Development Status
+Sprint 3 extends the current baseline toward final delivery readiness.
+
+The current Sprint 3 development scope includes:
+- documentation synchronization for runtime storage and interface planning
+- single-location JSON persistence under `WEB-INF/data`
+- minimal interface and data design for the remaining Sprint 3 stories
+- acceptance test checklist preparation for final demo rehearsal and regression checking
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,3 +133,47 @@ The current intermediate version includes:
 | **TA** | Profile Setup, Job List Viewing | Tianzi Xiong, Fangyu Chu | Must Have |
 | **MO** | Job Posting Form, My Jobs Dashboard | Wanhe Ji, Huishun Hu | Must Have |
 
+---
+
+## 3. Sprint 2 Member Task Allocation
+### **Group A: Administrator Module & Shared Backend Integration**
+**Members:** Sihan Chen & Tianxiao Ma
+
+* **Administrator Dashboard & Monitoring:**
+    * Extend the administrator module from a basic dashboard into a system-wide management interface.
+    * Display overview statistics, workload monitoring, user lists, and job lists based on the shared backend JSON data.
+* **Administrator Workflow & Data Control:**
+    * Implement administrator-side demand review and recruitment reopen workflow.
+    * Implement admin user management features including create user, delete user, and reset password.
+    * Keep `users.json`, `students.json`, `jobs.json`, and `applications.json` consistent across shared backend flows.
+
+### **Group B: TA (Applicant) Workflow Extension**
+**Members:** Tianzi Xiong & Fangyu Chu
+
+* **Applicant Profile & Supporting Documents:**
+    * Extend the applicant profile workflow with persistent profile updates and supporting document management.
+    * Implement attachment upload, deletion, and application-time document selection.
+* **Application Workflow Extension:**
+    * Extend the student-side recruitment workflow with job application submission, withdrawal, and status tracking.
+    * Improve the applicant UI so that students can browse jobs, manage applications, and review recruitment progress more clearly.
+
+### **Group C: MO (Module Organiser) Workflow Extension**
+**Members:** Wanhe Ji & Huishun Hu
+
+* **Demand / Job Lifecycle Control:**
+    * Extend MO-side recruitment management with demand submission, approval tracking, job publishing, editing, withdrawal, and controlled offline flow.
+    * Maintain lifecycle constraints for published jobs and active-application cases.
+* **Applicant Review & Hiring Operations:**
+    * Extend the applicants workflow with detail viewing, status updates, final hiring confirmation, and recruitment closure.
+    * Add MO notifications and hiring-history-related workflow support for more complete recruitment operation.
+
+---
+
+### **Summary Table for Sprint 2**
+
+| Category | Tasks | Assignees | Priority |
+| :--- | :--- | :--- | :--- |
+| **Admin / Shared** | Admin dashboard, workload, demand review, user management, shared data integration | Sihan Chen, Tianxiao Ma | Must Have |
+| **TA Extension** | Profile persistence, attachments, job application, withdrawal, status tracking | Tianzi Xiong, Fangyu Chu | Must Have |
+| **MO Extension** | Demand lifecycle, applicant review, hiring confirmation, notifications | Wanhe Ji, Huishun Hu | Must Have |
+

--- a/docs/Acceptance_Test_Checklist.md
+++ b/docs/Acceptance_Test_Checklist.md
@@ -1,0 +1,112 @@
+# Acceptance Test Checklist
+
+This checklist is prepared for Sprint 3 hand test, regression check, and final demo rehearsal.
+
+Status fields to fill during execution:
+
+- Pass/Fail
+- Evidence Note
+
+Recommended evidence:
+
+- screenshot
+- short terminal note
+- exported file name
+- observed JSON file path
+
+---
+
+## 1. Environment and Runtime Data
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| ENV-01 | Tester | Application is stopped. | 1. Confirm the presence of `users.json`, `students.json`, `jobs.json`, `applications.json`, `notifications.json`, `hiring_history.json`, and `system_settings.json` under `web/src/main/webapp/WEB-INF/data`.<br>2. Start Tomcat and open the system.<br>3. Log in with the demo accounts. | The system starts successfully and uses the JSON files under `WEB-INF/data`. |  |  |
+| ENV-02 | Tester | Application is running. | 1. Perform a data-changing action, for example student applies for a job.<br>2. Open the corresponding JSON file under `web/src/main/webapp/WEB-INF/data`.<br>3. Verify the new record exists. | Changes made through the UI are written directly to the JSON files under `WEB-INF/data`. |  |  |
+| ENV-03 | Tester | Application is running and one JSON file has already been updated. | 1. Restart Tomcat.<br>2. Reopen the same page.<br>3. Compare the page content with the JSON file under `WEB-INF/data`. | The modified data remains available after restart because `WEB-INF/data` is the single source of truth. |  |  |
+| ENV-04 | Tester | Application is stopped. | 1. Back up one JSON file under `WEB-INF/data` if needed.<br>2. Delete or rename the file.<br>3. Start the application again. | Missing files are recreated automatically with the expected default structure. |  |  |
+
+---
+
+## 2. Authentication and Access Guard
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| AUTH-01 | All Users | JSON files under `WEB-INF/data` contain the demo accounts. | 1. Open the login page.<br>2. Log in as Student using `student@demo.com / demo123`.<br>3. Repeat for Teacher and Admin accounts. | Each account is redirected to the correct role page. |  |  |
+| AUTH-02 | All Users | Login page is open. | 1. Submit an incorrect password.<br>2. Submit an empty login form. | The system shows an error and does not create a session. |  |  |
+| AUTH-03 | All Users | User is logged in. | 1. Click Logout.<br>2. Try reopening a protected page in the same browser tab. | Session is invalidated and the protected page is no longer accessible directly. |  |  |
+| AUTH-04 | Tester | No valid session for the target role. | 1. Request a protected URL such as `/pages/admin.jsp` or `/api/admin/dashboard` without a matching session. | Access is rejected or redirected according to the current auth filter behavior. |  |  |
+
+---
+
+## 3. Shared Password Change
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| PWD-01 | Student / MO / Admin | Role is logged in and the change-password feature is available. | 1. Submit the correct old password and a valid new password.<br>2. Log out.<br>3. Log in again using the new password. | Password is changed successfully and the new password works. |  |  |
+| PWD-02 | Student / MO / Admin | Role is logged in. | 1. Submit an incorrect old password.<br>2. Keep the new password fields valid. | The request is rejected and the stored password is unchanged. |  |  |
+| PWD-03 | Student / MO / Admin | Role is logged in. | 1. Submit mismatched `newPassword` and `confirmPassword`. | Validation error is shown and nothing is saved. |  |  |
+
+---
+
+## 4. Student Workflow
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| STU-01 | Student | Student is logged in. | 1. Open the jobs panel.<br>2. Search and filter available jobs if the UI provides those controls.<br>3. Open one job detail. | Available jobs load successfully and details are visible. |  |  |
+| STU-02 | Student | Student profile contains at least one uploaded attachment. | 1. Apply for an open job.<br>2. Select at least one attachment.<br>3. Submit the application. | A new application record is created and appears in the student's application list. |  |  |
+| STU-03 | Student | Student has one active non-hired application. | 1. Withdraw that application from the application list. | The application disappears from the active list or is shown as no longer active according to the current UI behavior. |  |  |
+| STU-04 | Student | Student has at least one hired application. | 1. Open the assigned jobs / my jobs / schedule view.<br>2. Inspect the listed assignment. | Only hired jobs are displayed, with module, organiser, weekly hours, schedule, location, and deadline. |  |  |
+| STU-05 | Student | Student has no hired applications. | 1. Open the assigned jobs / schedule view. | The system shows a clear empty state instead of a broken table or blank page. |  |  |
+
+---
+
+## 5. Module Organiser Workflow
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| MO-01 | Module Organiser | MO is logged in and owns at least one job with active applicants. | 1. Open the applicant list.<br>2. Mark one application as shortlisted.<br>3. Save a review note on the same record. | Status and note are saved and remain visible after refresh. |  |  |
+| MO-02 | Module Organiser | Same as MO-01. | 1. Filter applications by status.<br>2. Switch between at least two status values. | The list refreshes correctly and only matching records remain visible. |  |  |
+| MO-03 | Module Organiser | MO owns current and/or historical jobs. | 1. Open the posted-job history view.<br>2. Inspect at least one record. | Each history item shows job metadata including status, applicant count, hired count, created time, and deadline. |  |  |
+| MO-04 | Module Organiser | MO owns applicants and the export feature is available. | 1. Export applicants as CSV.<br>2. Open the exported file. | The file downloads successfully and contains the required columns. |  |  |
+| MO-05 | Module Organiser | Same as MO-04. | 1. Export applicants as JSON.<br>2. Open the exported file. | The JSON file downloads successfully and contains the expected applicant fields. |  |  |
+| MO-06 | Module Organiser | MO owns one job with shortlisted applicants. | 1. Confirm final hiring.<br>2. Refresh the applicant page.<br>3. Try changing a status again. | Recruitment becomes closed and the page is effectively read-only for further review changes on that job. |  |  |
+
+---
+
+## 6. Admin Workflow
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| ADM-01 | Admin | Admin is logged in. | 1. Open workload settings.<br>2. Save threshold `20`.<br>3. Reload the page.<br>4. Inspect `web/src/main/webapp/WEB-INF/data/system_settings.json`. | Saved threshold is loaded again and persisted directly in `system_settings.json`. |  |  |
+| ADM-02 | Admin | Runtime data contains hired records with different weekly-hour totals. | 1. Open the workload page.<br>2. Compare records against the threshold. | TAs over the threshold are marked with a visible warning label. |  |  |
+| ADM-03 | Admin | Admin dashboard contains jobs from more than one department or status. | 1. Filter the dashboard by department.<br>2. Filter again by status. | Job results are narrowed correctly without breaking dashboard rendering. |  |  |
+| ADM-04 | Admin | Weekly report export feature is available. | 1. Export the weekly report as CSV or TXT.<br>2. Open the downloaded file. | The file includes job title, organiser, status, hired count, and unfilled count. |  |  |
+| ADM-05 | Admin | At least one recruitment-closed job exists. | 1. Reopen the closed job from Admin.<br>2. Refresh Admin and MO pages. | Job is reopened successfully and the state change is visible in both places. |  |  |
+
+---
+
+## 7. Regression Checks
+
+| Test ID | Role | Preconditions | Steps | Expected Result | Pass/Fail | Evidence Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| REG-01 | Student | Student is logged in. | 1. Open and edit profile data.<br>2. Save changes.<br>3. Refresh the page. | Sprint 1/2 profile management still works after Sprint 3 changes. |  |  |
+| REG-02 | Student | Student is logged in. | 1. Upload one attachment.<br>2. Delete that attachment.<br>3. Refresh the page. | Attachment upload and delete still work. |  |  |
+| REG-03 | MO | MO is logged in. | 1. Create a demand.<br>2. Publish a job if allowed.<br>3. View applicants. | Sprint 1/2 MO demand, publish, and review chain still works. |  |  |
+| REG-04 | Admin | Admin is logged in. | 1. Open dashboard.<br>2. Create a user.<br>3. Reset password or delete a user if safe. | Sprint 2 admin management functions still work after Sprint 3 documentation/runtime updates. |  |  |
+| REG-05 | Tester | JSON data has been modified during any prior test. | 1. Restart Tomcat.<br>2. Re-check the modified records.<br>3. Confirm they still match the files under `WEB-INF/data`. | JSON data remains stable across restart and is still loaded from `WEB-INF/data`. |  |  |
+
+---
+
+## 8. Suggested Execution Order
+
+Recommended rehearsal order:
+
+1. `ENV-01` to `ENV-04`
+2. `AUTH-01` to `AUTH-04`
+3. `PWD-01` to `PWD-03`
+4. `STU-01` to `STU-05`
+5. `MO-01` to `MO-06`
+6. `ADM-01` to `ADM-05`
+7. `REG-01` to `REG-05`
+
+This order minimizes confusion between file checks, role switching, and regression evidence collection.

--- a/docs/Sprint3_Minimal_Design.md
+++ b/docs/Sprint3_Minimal_Design.md
@@ -1,0 +1,444 @@
+# Sprint 3 Minimal Design
+
+## 1. Purpose
+
+This document defines the minimum interface and data design for Sprint 3.
+
+Design level:
+
+- cover all Sprint 3 stories at a practical implementation level
+- keep core behavior decision-complete
+- leave obvious secondary enhancements extensible instead of over-designing them now
+
+This design must remain compatible with the existing Servlet/JSP architecture, JSON file persistence, and `ApiResponse` response wrapper style.
+
+---
+
+## 2. Runtime Data Strategy
+
+Runtime data is stored directly under the web application data directory:
+
+```text
+web/src/main/webapp/WEB-INF/data/
+```
+
+Managed JSON files:
+
+- `users.json`
+- `students.json`
+- `jobs.json`
+- `applications.json`
+- `notifications.json`
+- `hiring_history.json`
+- `system_settings.json`
+
+Initialization rules:
+
+1. Existing files under `WEB-INF/data` are used directly.
+2. If a required file is missing, it is created automatically in `WEB-INF/data`.
+3. List-based files are initialized as `[]`.
+4. `system_settings.json` is initialized with the default settings object if missing.
+
+Default settings object:
+
+```json
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "ISO-8601"
+}
+```
+
+Compatibility rules:
+
+- old JSON records must remain readable without migration scripts
+- missing new fields default to `null`, empty string, or false-like behavior
+- new code must not require historical records to be rewritten
+- no duplicated runtime copy is introduced; the single source of truth remains `WEB-INF/data`
+
+---
+
+## 3. Shared Calculation Rules
+
+### Weekly Hours
+
+The canonical weekly-hours value used by Admin workload, TA assigned jobs, and related Sprint 3 displays is:
+
+1. use `job.hours` when `hours > 0`
+2. otherwise use `round((hourMin + hourMax) / 2)`
+3. otherwise fall back to `0`
+
+This rule avoids inconsistent workload calculations between old and new job records.
+
+### Status Vocabulary
+
+The application status set remains:
+
+- `pending`
+- `viewed`
+- `shortlisted`
+- `hired`
+- `rejected`
+
+Student-facing labels may map these backend values into UI-friendly wording, but persistence keeps the existing backend vocabulary.
+
+---
+
+## 4. Data Model Additions
+
+### `JobPosting`
+
+New optional fields:
+
+- `department: String`
+- `schedule: String`
+
+Usage:
+
+- `department` is entered during MO demand create / edit
+- `schedule` is entered during MO publish / edit
+
+Compatibility:
+
+- older records may omit both fields
+- UI displays `-` when the value is absent
+- Admin department filter only lists non-empty department values found in current job data
+
+### `ApplicationRecord`
+
+New optional fields:
+
+- `moNote: String`
+- `decisionUpdatedAt: String`
+
+Usage:
+
+- `moNote` stores organiser-only review notes
+- `decisionUpdatedAt` stores the last MO decision timestamp when status or note changes
+
+Compatibility:
+
+- old records may omit both fields
+- absent `moNote` is treated as an empty note
+
+### `SystemSettings`
+
+Object structure:
+
+```json
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "ISO-8601"
+}
+```
+
+Validation:
+
+- `workloadThresholdHours` must be a positive integer
+
+---
+
+## 5. API Design
+
+All JSON APIs continue to use the existing `ApiResponse` envelope unless the endpoint returns a direct downloadable file.
+
+### 5.1 Admin
+
+#### `GET /api/admin/dashboard?status={all|draft|open|closed|withdrawn}&department={all|value}`
+
+Purpose:
+
+- extend the current dashboard with optional job filtering
+
+Query rules:
+
+- both query parameters are optional
+- omitted values behave as `all`
+- unsupported values return validation error
+
+Response:
+
+- keep the existing dashboard response shape unchanged
+- filtering only narrows the returned job list and dashboard-derived job statistics
+- workload and user lists remain available in the same response payload
+
+Data sources:
+
+- `users.json`
+- `jobs.json`
+- `applications.json`
+
+#### `GET /api/admin/settings/workload-threshold`
+
+Purpose:
+
+- load the current workload threshold
+
+Response data:
+
+```json
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "2026-04-16T08:00:00Z"
+}
+```
+
+Data source:
+
+- `system_settings.json`
+
+#### `POST /api/admin/settings/workload-threshold`
+
+Purpose:
+
+- save the global workload threshold
+
+Request body:
+
+```json
+{
+  "workloadThresholdHours": 20
+}
+```
+
+Response data:
+
+```json
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "2026-04-16T08:00:00Z",
+  "saved": true
+}
+```
+
+Validation:
+
+- value must be a positive integer
+
+#### `GET /api/admin/reports/weekly?format={csv|txt}`
+
+Purpose:
+
+- export a weekly recruitment summary report
+
+Behavior:
+
+- returns downloadable attachment output
+- no `ApiResponse` envelope is required for the file body
+
+Required report content:
+
+- module / job title
+- organiser name
+- job status
+- positions
+- hired count
+- unfilled count
+- recruitment closed flag
+
+Data sources:
+
+- `jobs.json`
+- `applications.json`
+
+### 5.2 Shared
+
+#### `POST /api/account/change-password`
+
+Purpose:
+
+- authenticated self-service password change
+
+Request body:
+
+```json
+{
+  "oldPassword": "current-value",
+  "newPassword": "new-value",
+  "confirmPassword": "new-value"
+}
+```
+
+Response data:
+
+```json
+{
+  "changed": true
+}
+```
+
+Validation:
+
+- all fields are required
+- `oldPassword` must match the current user record
+- `newPassword` and `confirmPassword` must match
+- `newPassword` must differ from `oldPassword`
+
+Data source:
+
+- `users.json`
+
+### 5.3 Module Organiser
+
+#### `POST /api/mo/applications/status`
+
+Purpose:
+
+- extend the current application-status endpoint with organiser notes
+
+Request body:
+
+```json
+{
+  "applicationId": "app_001",
+  "status": "shortlisted",
+  "note": "Strong Java basics and prior tutoring experience."
+}
+```
+
+Response data:
+
+- keep the current updated-application response style
+- response may include the saved note and updated timestamp if convenient, but it must at least preserve current consumer compatibility
+
+Validation:
+
+- current MO must own the target application's job
+- recruitment-closed jobs remain read-only
+- `status` must stay within the existing allowed values
+- note is optional, but if present must be stored exactly as submitted after trimming outer whitespace
+
+Data source:
+
+- `applications.json`
+
+#### `GET /api/mo/jobs/history`
+
+Purpose:
+
+- return a history summary of all jobs owned by the current MO
+
+Response data:
+
+```json
+{
+  "items": [
+    {
+      "jobId": "job_001",
+      "moduleCode": "EBU6304",
+      "title": "Teaching Assistant",
+      "department": "Computer Science",
+      "status": "closed",
+      "applicantCount": 6,
+      "hiredCount": 2,
+      "published": true,
+      "recruitmentClosed": true,
+      "createdAt": "2026-04-01T08:00:00Z",
+      "deadline": "2026-04-20"
+    }
+  ]
+}
+```
+
+Data sources:
+
+- `jobs.json`
+- `applications.json`
+
+#### `GET /api/mo/applications/export?format={csv|json}&jobId={optional}&status={optional}`
+
+Purpose:
+
+- export applicant data owned by the current MO
+
+Rules:
+
+- `format` is required and must be `csv` or `json`
+- `jobId` is optional
+- `status` is optional and filters by current application status
+
+Export columns / fields:
+
+- application ID
+- job ID
+- job title
+- student name
+- student number
+- programme
+- applied time
+- status
+- skills
+- `moNote`
+
+Data sources:
+
+- `applications.json`
+- `jobs.json`
+- `students.json`
+
+### 5.4 Student
+
+#### `GET /api/student/my-jobs`
+
+Purpose:
+
+- return confirmed assignments for the current student
+
+Response data:
+
+```json
+{
+  "items": [
+    {
+      "applicationId": "app_001",
+      "jobId": "job_001",
+      "moduleCode": "EBU6304",
+      "title": "Teaching Assistant",
+      "teacherName": "Dr. Smith",
+      "weeklyHours": 10,
+      "schedule": "Wed 14:00-16:00",
+      "location": "offline",
+      "deadline": "2026-04-20",
+      "recruitmentClosed": true
+    }
+  ]
+}
+```
+
+Rules:
+
+- only `hired` applications are returned
+- withdrawn, rejected, pending, viewed, and shortlisted records are excluded
+
+Data sources:
+
+- `applications.json`
+- `jobs.json`
+
+---
+
+## 6. Input Ownership
+
+Field ownership is fixed as follows:
+
+- `department`
+  - entered when MO creates or edits a demand
+- `schedule`
+  - entered when MO publishes or edits a job
+- `moNote`
+  - entered by MO during application review
+- `workloadThresholdHours`
+  - entered by Admin through the settings API
+
+This prevents later ambiguity about where Sprint 3 data should come from.
+
+---
+
+## 7. Non-Goals for This Minimal Design
+
+The following are intentionally left out of the Sprint 3 minimal design:
+
+- database migration or ORM support
+- batch applicant editing beyond what can reuse the current status-update flow
+- complex scheduling objects beyond a single `schedule` string
+- advanced report templating or Excel export
+- password complexity policy beyond basic validation

--- a/web/src/main/java/com/ta/model/SystemSettings.java
+++ b/web/src/main/java/com/ta/model/SystemSettings.java
@@ -1,0 +1,22 @@
+package com.ta.model;
+
+public class SystemSettings {
+    private Integer workloadThresholdHours;
+    private String updatedAt;
+
+    public Integer getWorkloadThresholdHours() {
+        return workloadThresholdHours;
+    }
+
+    public void setWorkloadThresholdHours(Integer workloadThresholdHours) {
+        this.workloadThresholdHours = workloadThresholdHours;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/web/src/main/java/com/ta/util/JsonUtility.java
+++ b/web/src/main/java/com/ta/util/JsonUtility.java
@@ -8,6 +8,7 @@ import com.ta.model.HiringHistoryRecord;
 import com.ta.model.JobPosting;
 import com.ta.model.NotificationRecord;
 import com.ta.model.StudentProfile;
+import com.ta.model.SystemSettings;
 import com.ta.model.User;
 import jakarta.servlet.ServletContext;
 
@@ -18,11 +19,13 @@ import java.io.Writer;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
 public final class JsonUtility {
     private static final String DATA_ROOT = "/WEB-INF/data/";
+    private static final String SYSTEM_SETTINGS_FILE = "system_settings.json";
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final Type USER_LIST_TYPE = new TypeToken<List<User>>() { }.getType();
     private static final Type STUDENT_LIST_TYPE = new TypeToken<List<StudentProfile>>() { }.getType();
@@ -39,7 +42,7 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveUsers(ServletContext context, List<User> users) throws IOException {
-        writeList(context, "users.json", users);
+        writeJson(context, "users.json", users);
     }
 
     public static synchronized List<StudentProfile> loadStudents(ServletContext context) throws IOException {
@@ -47,7 +50,7 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveStudents(ServletContext context, List<StudentProfile> students) throws IOException {
-        writeList(context, "students.json", students);
+        writeJson(context, "students.json", students);
     }
 
     public static synchronized List<JobPosting> loadJobs(ServletContext context) throws IOException {
@@ -55,7 +58,7 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveJobs(ServletContext context, List<JobPosting> jobs) throws IOException {
-        writeList(context, "jobs.json", jobs);
+        writeJson(context, "jobs.json", jobs);
     }
 
     public static synchronized List<ApplicationRecord> loadApplications(ServletContext context) throws IOException {
@@ -63,7 +66,7 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveApplications(ServletContext context, List<ApplicationRecord> applications) throws IOException {
-        writeList(context, "applications.json", applications);
+        writeJson(context, "applications.json", applications);
     }
 
     public static synchronized List<HiringHistoryRecord> loadHiringHistory(ServletContext context) throws IOException {
@@ -71,7 +74,7 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveHiringHistory(ServletContext context, List<HiringHistoryRecord> records) throws IOException {
-        writeList(context, "hiring_history.json", records);
+        writeJson(context, "hiring_history.json", records);
     }
 
     public static synchronized List<NotificationRecord> loadNotifications(ServletContext context) throws IOException {
@@ -79,7 +82,19 @@ public final class JsonUtility {
     }
 
     public static synchronized void saveNotifications(ServletContext context, List<NotificationRecord> records) throws IOException {
-        writeList(context, "notifications.json", records);
+        writeJson(context, "notifications.json", records);
+    }
+
+    public static synchronized SystemSettings loadSystemSettings(ServletContext context) throws IOException {
+        File file = resolveDataFile(context, SYSTEM_SETTINGS_FILE);
+        try (Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            SystemSettings settings = GSON.fromJson(reader, SystemSettings.class);
+            return normalizeSettings(settings);
+        }
+    }
+
+    public static synchronized void saveSystemSettings(ServletContext context, SystemSettings settings) throws IOException {
+        writeJson(context, SYSTEM_SETTINGS_FILE, normalizeSettings(settings));
     }
 
     private static <T> List<T> readList(ServletContext context, String fileName, Type listType) throws IOException {
@@ -90,7 +105,7 @@ public final class JsonUtility {
         }
     }
 
-    private static void writeList(ServletContext context, String fileName, Object data) throws IOException {
+    private static void writeJson(ServletContext context, String fileName, Object data) throws IOException {
         File file = resolveDataFile(context, fileName);
         try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             GSON.toJson(data, writer);
@@ -98,27 +113,56 @@ public final class JsonUtility {
     }
 
     private static File resolveDataFile(ServletContext context, String fileName) throws IOException {
-        String realPath = context.getRealPath(DATA_ROOT + fileName);
+        String resourcePath = DATA_ROOT + fileName;
+        String realPath = context.getRealPath(resourcePath);
         if (realPath == null) {
-            // 如果getRealPath返回null，尝试构造路径
-            String contextPath = context.getRealPath("/");
-            if (contextPath != null) {
-                realPath = contextPath + DATA_ROOT.substring(1) + fileName;
+            String contextRoot = context.getRealPath("/");
+            if (contextRoot != null) {
+                realPath = contextRoot + DATA_ROOT.substring(1) + fileName;
             }
         }
+
+        if (realPath == null) {
+            throw new IOException("Unable to resolve data file path for " + fileName);
+        }
+
         File dataFile = new File(realPath);
         File dataDir = dataFile.getParentFile();
-
-        // 确保数据目录存在
-        if (!dataDir.exists()) {
+        if (dataDir != null && !dataDir.exists()) {
             Files.createDirectories(dataDir.toPath());
         }
 
-        // 如果文件不存在，创建空的 JSON 数组文件
         if (!dataFile.exists()) {
-            Files.writeString(dataFile.toPath(), "[]", StandardCharsets.UTF_8);
+            Files.writeString(dataFile.toPath(), defaultJsonFor(fileName), StandardCharsets.UTF_8);
         }
 
         return dataFile;
+    }
+
+    private static String defaultJsonFor(String fileName) {
+        if (SYSTEM_SETTINGS_FILE.equals(fileName)) {
+            return GSON.toJson(defaultSystemSettings());
+        }
+        return "[]";
+    }
+
+    private static SystemSettings normalizeSettings(SystemSettings settings) {
+        if (settings == null) {
+            return defaultSystemSettings();
+        }
+        if (settings.getWorkloadThresholdHours() == null || settings.getWorkloadThresholdHours() <= 0) {
+            settings.setWorkloadThresholdHours(20);
+        }
+        if (settings.getUpdatedAt() == null || settings.getUpdatedAt().isBlank()) {
+            settings.setUpdatedAt(Instant.now().toString());
+        }
+        return settings;
+    }
+
+    private static SystemSettings defaultSystemSettings() {
+        SystemSettings settings = new SystemSettings();
+        settings.setWorkloadThresholdHours(20);
+        settings.setUpdatedAt(Instant.now().toString());
+        return settings;
     }
 }

--- a/web/src/main/webapp/WEB-INF/data/system_settings.json
+++ b/web/src/main/webapp/WEB-INF/data/system_settings.json
@@ -1,0 +1,4 @@
+{
+  "workloadThresholdHours": 20,
+  "updatedAt": "2026-04-16T00:00:00Z"
+}


### PR DESCRIPTION
## Summary
This PR synchronizes the project documentation with Sprint 3 development and updates the JSON storage strategy to use a single source of truth under `WEB-INF/data`.

## Changes
- updated `README.md` to reflect Sprint 3 development in progress
- added Sprint 3 focus section
- added runtime data storage explanation for single-location JSON persistence
- added project documentation links
- added `docs/Sprint3_Minimal_Design.md`
- added `docs/Acceptance_Test_Checklist.md`
- updated `JsonUtility.java` to use only `WEB-INF/data`
- added `SystemSettings.java`
- added `web/src/main/webapp/WEB-INF/data/system_settings.json`
- updated `Function_Details.md` for Sprint 3 documentation synchronization

Closes #58 
