### PR TITLE
Add MO_08 job history and MO_09 applicant export

### DIFF
--- a/web/src/main/java/com/ta/dto/mo/MoApplicationExportRow.java
+++ b/web/src/main/java/com/ta/dto/mo/MoApplicationExportRow.java
@@ -1,0 +1,58 @@
+package com.ta.dto.mo;
+
+public class MoApplicationExportRow {
+    private String name;
+    private String applicant_id;
+    private String major;
+    private String application_time;
+    private String status;
+    private String skills;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getApplicant_id() {
+        return applicant_id;
+    }
+
+    public void setApplicant_id(String applicant_id) {
+        this.applicant_id = applicant_id;
+    }
+
+    public String getMajor() {
+        return major;
+    }
+
+    public void setMajor(String major) {
+        this.major = major;
+    }
+
+    public String getApplication_time() {
+        return application_time;
+    }
+
+    public void setApplication_time(String application_time) {
+        this.application_time = application_time;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getSkills() {
+        return skills;
+    }
+
+    public void setSkills(String skills) {
+        this.skills = skills;
+    }
+}

--- a/web/src/main/java/com/ta/dto/mo/MoDemandItemResponse.java
+++ b/web/src/main/java/com/ta/dto/mo/MoDemandItemResponse.java
@@ -20,6 +20,7 @@ public class MoDemandItemResponse {
     private String closedAt;
     private String createdAt;
     private String updatedAt;
+    private String publishedAt;
 
     public String getJobId() {
         return jobId;
@@ -139,5 +140,13 @@ public class MoDemandItemResponse {
 
     public void setUpdatedAt(String updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public String getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(String publishedAt) {
+        this.publishedAt = publishedAt;
     }
 }

--- a/web/src/main/java/com/ta/dto/mo/MoJobHistoryItemResponse.java
+++ b/web/src/main/java/com/ta/dto/mo/MoJobHistoryItemResponse.java
@@ -1,0 +1,121 @@
+package com.ta.dto.mo;
+
+public class MoJobHistoryItemResponse {
+    private String jobId;
+    private String courseName;
+    private String department;
+    private String status;
+    private Boolean published;
+    private Boolean withdrawn;
+    private Boolean recruitmentClosed;
+    private Integer applicantCount;
+    private Integer hireCount;
+    private String releaseTime;
+    private String deadline;
+    private String createdAt;
+    private String updatedAt;
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public void setCourseName(String courseName) {
+        this.courseName = courseName;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Boolean getPublished() {
+        return published;
+    }
+
+    public void setPublished(Boolean published) {
+        this.published = published;
+    }
+
+    public Boolean getWithdrawn() {
+        return withdrawn;
+    }
+
+    public void setWithdrawn(Boolean withdrawn) {
+        this.withdrawn = withdrawn;
+    }
+
+    public Boolean getRecruitmentClosed() {
+        return recruitmentClosed;
+    }
+
+    public void setRecruitmentClosed(Boolean recruitmentClosed) {
+        this.recruitmentClosed = recruitmentClosed;
+    }
+
+    public Integer getApplicantCount() {
+        return applicantCount;
+    }
+
+    public void setApplicantCount(Integer applicantCount) {
+        this.applicantCount = applicantCount;
+    }
+
+    public Integer getHireCount() {
+        return hireCount;
+    }
+
+    public void setHireCount(Integer hireCount) {
+        this.hireCount = hireCount;
+    }
+
+    public String getReleaseTime() {
+        return releaseTime;
+    }
+
+    public void setReleaseTime(String releaseTime) {
+        this.releaseTime = releaseTime;
+    }
+
+    public String getDeadline() {
+        return deadline;
+    }
+
+    public void setDeadline(String deadline) {
+        this.deadline = deadline;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/web/src/main/java/com/ta/dto/mo/MoJobHistoryResponse.java
+++ b/web/src/main/java/com/ta/dto/mo/MoJobHistoryResponse.java
@@ -1,0 +1,16 @@
+package com.ta.dto.mo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MoJobHistoryResponse {
+    private List<MoJobHistoryItemResponse> items = new ArrayList<>();
+
+    public List<MoJobHistoryItemResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<MoJobHistoryItemResponse> items) {
+        this.items = items != null ? items : new ArrayList<>();
+    }
+}

--- a/web/src/main/java/com/ta/model/JobPosting.java
+++ b/web/src/main/java/com/ta/model/JobPosting.java
@@ -24,6 +24,8 @@ public class JobPosting {
     // MO iteration 1 agreed fields
     private Integer hourMin;
     private Integer hourMax;
+    private String department;
+    private String schedule;
     private String approvalStatus;
     private Boolean published;
     private Boolean withdrawn;
@@ -31,10 +33,13 @@ public class JobPosting {
     private String requirements;
     private String createdAt;
     private String updatedAt;
+    /** ISO timestamp when this job was released/published for applicants. */
+    private String publishedAt;
     /** MO_04: set true after final hiring confirmation. */
     private Boolean recruitmentClosed;
     /** ISO timestamp when recruitment is closed. */
     private String closedAt;
+    
 
     public JobPosting() {
     }
@@ -127,6 +132,22 @@ public class JobPosting {
         this.hourMax = hourMax;
     }
 
+    public String getDepartment() {
+        return department;
+}
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(String schedule) {
+        this.schedule = schedule;
+    }
+    
     public String getApprovalStatus() {
         return approvalStatus;
     }
@@ -181,6 +202,14 @@ public class JobPosting {
 
     public void setUpdatedAt(String updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public String getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(String publishedAt) {
+        this.publishedAt = publishedAt;
     }
 
     public Boolean getRecruitmentClosed() {

--- a/web/src/main/java/com/ta/service/mo/MoApplicationExportService.java
+++ b/web/src/main/java/com/ta/service/mo/MoApplicationExportService.java
@@ -1,0 +1,168 @@
+package com.ta.service.mo;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ta.constant.ErrorCodes;
+import com.ta.dto.mo.MoApplicationExportRow;
+import com.ta.model.ApplicationRecord;
+import com.ta.model.JobPosting;
+import com.ta.model.StudentProfile;
+import com.ta.util.JsonUtility;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class MoApplicationExportService {
+    private static final Gson EXPORT_GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String CSV_HEADER = "name,applicant_id,major,application_time,status,skills";
+
+    public ExportFile buildExport(ServletContext context, String moId, String jobId, String scope, String format) {
+        validateRequest(jobId, scope, format);
+        try {
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            JobPosting job = jobs.stream()
+                    .filter(j -> jobId.equals(j.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new MoBusinessException(
+                            ErrorCodes.JOB_NOT_FOUND,
+                            "Job not found.",
+                            HttpServletResponse.SC_NOT_FOUND
+                    ));
+            if (!moId.equals(job.getTeacherId())) {
+                throw new MoBusinessException(
+                        ErrorCodes.FORBIDDEN_NOT_OWNER,
+                        "You can only export applications for your own jobs.",
+                        HttpServletResponse.SC_FORBIDDEN
+                );
+            }
+
+            List<MoApplicationExportRow> rows = buildRows(context, jobId, scope);
+            if ("json".equalsIgnoreCase(format)) {
+                String json = EXPORT_GSON.toJson(rows);
+                return new ExportFile(fileName(job, scope, "json"), "application/json;charset=UTF-8", json.getBytes(StandardCharsets.UTF_8));
+            }
+
+            String csv = toCsv(rows);
+            byte[] csvBytes = ("\uFEFF" + csv).getBytes(StandardCharsets.UTF_8);
+            return new ExportFile(fileName(job, scope, "csv"), "text/csv;charset=UTF-8", csvBytes);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to export applications.", e);
+        }
+    }
+
+    private void validateRequest(String jobId, String scope, String format) {
+        if (jobId == null || jobId.isBlank()) {
+            throw new MoBusinessException(ErrorCodes.VALIDATION_ERROR, "jobId is required.", HttpServletResponse.SC_BAD_REQUEST);
+        }
+        if (!"all".equalsIgnoreCase(scope) && !"shortlisted".equalsIgnoreCase(scope)) {
+            throw new MoBusinessException(ErrorCodes.VALIDATION_ERROR, "scope must be all or shortlisted.", HttpServletResponse.SC_BAD_REQUEST);
+        }
+        if (!"csv".equalsIgnoreCase(format) && !"json".equalsIgnoreCase(format)) {
+            throw new MoBusinessException(ErrorCodes.VALIDATION_ERROR, "format must be csv or json.", HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    private List<MoApplicationExportRow> buildRows(ServletContext context, String jobId, String scope) throws IOException {
+        List<ApplicationRecord> applications = JsonUtility.loadApplications(context);
+        List<StudentProfile> profiles = JsonUtility.loadStudents(context);
+        Map<String, StudentProfile> profileByUserId = profiles.stream()
+                .filter(profile -> profile.getUserId() != null)
+                .collect(Collectors.toMap(StudentProfile::getUserId, Function.identity(), (a, b) -> a));
+
+        List<MoApplicationExportRow> rows = new ArrayList<>();
+        for (ApplicationRecord application : applications) {
+            if (!application.isActive() || !jobId.equals(application.getJobId())) {
+                continue;
+            }
+            if ("shortlisted".equalsIgnoreCase(scope) && !"shortlisted".equalsIgnoreCase(application.getStatus())) {
+                continue;
+            }
+            StudentProfile profile = profileByUserId.get(application.getStudentId());
+            rows.add(toRow(application, profile));
+        }
+        rows.sort(Comparator.comparing(MoApplicationExportRow::getApplication_time, Comparator.nullsLast(String::compareTo)).reversed());
+        return rows;
+    }
+
+    private MoApplicationExportRow toRow(ApplicationRecord application, StudentProfile profile) {
+        MoApplicationExportRow row = new MoApplicationExportRow();
+        row.setName(firstNonBlank(application.getStudentName(), profile == null ? null : profile.getName(), application.getStudentId()));
+        row.setApplicant_id(firstNonBlank(application.getStudentNo(), profile == null ? null : profile.getStudentId(), application.getStudentId()));
+        row.setMajor(firstNonBlank(profile == null ? null : profile.getProgramme(), application.getCourseGrade(), ""));
+        row.setApplication_time(safe(application.getAppliedAt()));
+        row.setStatus(safe(application.getStatus()));
+        row.setSkills(safe(profile == null ? null : profile.getSkills()));
+        return row;
+    }
+
+    private String toCsv(List<MoApplicationExportRow> rows) {
+        StringBuilder sb = new StringBuilder(CSV_HEADER).append("\r\n");
+        for (MoApplicationExportRow row : rows) {
+            sb.append(csvCell(row.getName())).append(',')
+                    .append(csvCell(row.getApplicant_id())).append(',')
+                    .append(csvCell(row.getMajor())).append(',')
+                    .append(csvCell(row.getApplication_time())).append(',')
+                    .append(csvCell(row.getStatus())).append(',')
+                    .append(csvCell(row.getSkills())).append("\r\n");
+        }
+        return sb.toString();
+    }
+
+    private String csvCell(String value) {
+        String text = safe(value);
+        boolean needsQuote = text.contains(",") || text.contains("\"") || text.contains("\n") || text.contains("\r");
+        String escaped = text.replace("\"", "\"\"");
+        return needsQuote ? "\"" + escaped + "\"" : escaped;
+    }
+
+    private String fileName(JobPosting job, String scope, String extension) {
+        String base = firstNonBlank(job.getModuleCode(), job.getTitle(), job.getId());
+        String safeBase = base.replaceAll("[^A-Za-z0-9_-]+", "_");
+        return safeBase + "_" + scope.toLowerCase() + "_applicants." + extension.toLowerCase();
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    public static class ExportFile {
+        private final String fileName;
+        private final String contentType;
+        private final byte[] content;
+
+        public ExportFile(String fileName, String contentType, byte[] content) {
+            this.fileName = fileName;
+            this.contentType = contentType;
+            this.content = content;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public byte[] getContent() {
+            return content;
+        }
+    }
+}

--- a/web/src/main/java/com/ta/service/mo/MoDemandService.java
+++ b/web/src/main/java/com/ta/service/mo/MoDemandService.java
@@ -133,6 +133,7 @@ public class MoDemandService {
         item.setClosedAt(job.getClosedAt());
         item.setCreatedAt(job.getCreatedAt());
         item.setUpdatedAt(job.getUpdatedAt());
+        item.setPublishedAt(job.getPublishedAt());
         return item;
     }
 

--- a/web/src/main/java/com/ta/service/mo/MoJobHistoryService.java
+++ b/web/src/main/java/com/ta/service/mo/MoJobHistoryService.java
@@ -1,0 +1,94 @@
+package com.ta.service.mo;
+
+import com.ta.dto.mo.MoJobHistoryItemResponse;
+import com.ta.dto.mo.MoJobHistoryResponse;
+import com.ta.model.ApplicationRecord;
+import com.ta.model.JobPosting;
+import com.ta.util.JsonUtility;
+import jakarta.servlet.ServletContext;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MoJobHistoryService {
+
+    public MoJobHistoryResponse listHistory(ServletContext context, String moId) {
+        try {
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            List<ApplicationRecord> applications = JsonUtility.loadApplications(context);
+            Map<String, Integer> applicantCountByJobId = new HashMap<>();
+            Map<String, Integer> hireCountByJobId = new HashMap<>();
+
+            for (ApplicationRecord application : applications) {
+                if (application.getJobId() == null || !application.isActive()) {
+                    continue;
+                }
+                applicantCountByJobId.merge(application.getJobId(), 1, Integer::sum);
+                if ("hired".equalsIgnoreCase(application.getStatus())) {
+                    hireCountByJobId.merge(application.getJobId(), 1, Integer::sum);
+                }
+            }
+
+            List<MoJobHistoryItemResponse> items = jobs.stream()
+                    .filter(job -> moId.equals(job.getTeacherId()))
+                    .map(job -> toHistoryItem(job, applicantCountByJobId, hireCountByJobId))
+                    .sorted(Comparator.comparing(MoJobHistoryItemResponse::getReleaseTime, Comparator.nullsLast(String::compareTo)).reversed())
+                    .toList();
+
+            MoJobHistoryResponse response = new MoJobHistoryResponse();
+            response.setItems(items);
+            return response;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load MO job history.", e);
+        }
+    }
+
+    private MoJobHistoryItemResponse toHistoryItem(JobPosting job,
+                                                   Map<String, Integer> applicantCountByJobId,
+                                                   Map<String, Integer> hireCountByJobId) {
+        MoJobHistoryItemResponse item = new MoJobHistoryItemResponse();
+        item.setJobId(job.getId());
+        item.setCourseName(job.getTitle());
+        item.setDepartment(job.getDepartment());
+        item.setStatus(resolveDisplayStatus(job));
+        item.setPublished(Boolean.TRUE.equals(job.getPublished()));
+        item.setWithdrawn(Boolean.TRUE.equals(job.getWithdrawn()));
+        item.setRecruitmentClosed(Boolean.TRUE.equals(job.getRecruitmentClosed()));
+        item.setApplicantCount(applicantCountByJobId.getOrDefault(job.getId(), 0));
+        item.setHireCount(hireCountByJobId.getOrDefault(job.getId(), 0));
+        item.setReleaseTime(resolveReleaseTime(job));
+        item.setDeadline(job.getDeadline());
+        item.setCreatedAt(job.getCreatedAt());
+        item.setUpdatedAt(job.getUpdatedAt());
+        return item;
+    }
+
+    private String resolveDisplayStatus(JobPosting job) {
+        if (Boolean.TRUE.equals(job.getRecruitmentClosed())) {
+            return "recruitment_closed";
+        }
+        if (Boolean.TRUE.equals(job.getWithdrawn())) {
+            return "withdrawn";
+        }
+        if (Boolean.TRUE.equals(job.getPublished())) {
+            return job.getStatus() == null || job.getStatus().isBlank() ? "open" : job.getStatus();
+        }
+        if (job.getApprovalStatus() != null && !job.getApprovalStatus().isBlank()) {
+            return job.getApprovalStatus();
+        }
+        return job.getStatus() == null || job.getStatus().isBlank() ? "draft" : job.getStatus();
+    }
+
+    private String resolveReleaseTime(JobPosting job) {
+        if (job.getPublishedAt() != null && !job.getPublishedAt().isBlank()) {
+            return job.getPublishedAt();
+        }
+        if (Boolean.TRUE.equals(job.getPublished()) && job.getUpdatedAt() != null && !job.getUpdatedAt().isBlank()) {
+            return job.getUpdatedAt();
+        }
+        return job.getCreatedAt();
+    }
+}

--- a/web/src/main/java/com/ta/service/mo/MoJobService.java
+++ b/web/src/main/java/com/ta/service/mo/MoJobService.java
@@ -65,6 +65,7 @@ public class MoJobService {
             job.setPublished(true);
             job.setWithdrawn(false);
             job.setStatus("open");
+            job.setPublishedAt(now);
             job.setUpdatedAt(now);
 
             JsonUtility.saveJobs(context, jobs);
@@ -193,6 +194,45 @@ public class MoJobService {
         }
     }
 
+    public MoDemandItemResponse reuseJob(ServletContext context, String moId, String sourceJobId) {
+        try {
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            JobPosting source = findOwnedJob(jobs, moId, sourceJobId);
+            String now = Instant.now().toString();
+
+            JobPosting copied = new JobPosting();
+            copied.setId("job_" + java.util.UUID.randomUUID().toString().replace("-", ""));
+            copied.setTeacherId(source.getTeacherId());
+            copied.setTeacherName(source.getTeacherName());
+            copied.setModuleCode(source.getModuleCode());
+            copied.setTitle(source.getTitle());
+            copied.setHours(source.getHours());
+            copied.setPositions(source.getPositions());
+            copied.setHourMin(source.getHourMin());
+            copied.setHourMax(source.getHourMax());
+            copied.setDepartment(source.getDepartment());
+            copied.setSchedule(source.getSchedule());
+            copied.setLocation(source.getLocation());
+            copied.setRequirements(source.getRequirements());
+            copied.setApprovalStatus("approved");
+            copied.setPublished(false);
+            copied.setWithdrawn(false);
+            copied.setStatus("draft");
+            copied.setDeadline(null);
+            copied.setPublishedAt(null);
+            copied.setRecruitmentClosed(false);
+            copied.setClosedAt(null);
+            copied.setCreatedAt(now);
+            copied.setUpdatedAt(now);
+
+            jobs.add(copied);
+            JsonUtility.saveJobs(context, jobs);
+            return toDemandItem(copied);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to reuse job.", e);
+        }
+    }
+
     private JobPosting findOwnedJob(List<JobPosting> jobs, String moId, String jobId) {
         JobPosting job = jobs.stream()
                 .filter(j -> jobId.equals(j.getId()))
@@ -289,6 +329,7 @@ public class MoJobService {
         item.setClosedAt(job.getClosedAt());
         item.setCreatedAt(job.getCreatedAt());
         item.setUpdatedAt(job.getUpdatedAt());
+        item.setPublishedAt(job.getPublishedAt());
         return item;
     }
 

--- a/web/src/main/java/com/ta/web/mo/MoApplicationExportServlet.java
+++ b/web/src/main/java/com/ta/web/mo/MoApplicationExportServlet.java
@@ -1,0 +1,47 @@
+package com.ta.web.mo;
+
+import com.ta.constant.ErrorCodes;
+import com.ta.service.mo.MoApplicationExportService;
+import com.ta.service.mo.MoApplicationExportService.ExportFile;
+import com.ta.service.mo.MoBusinessException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "MoApplicationExportServlet", urlPatterns = {"/api/mo/applications/export"})
+public class MoApplicationExportServlet extends MoBaseServlet {
+    private final MoApplicationExportService moApplicationExportService = new MoApplicationExportService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            String moId = getMoIdFromSession(req);
+            if (moId == null || moId.isBlank()) {
+                writeError(resp, HttpServletResponse.SC_UNAUTHORIZED, ErrorCodes.UNAUTHORIZED, "MO login required.");
+                return;
+            }
+
+            String jobId = req.getParameter("jobId");
+            String scope = defaultIfBlank(req.getParameter("scope"), "all");
+            String format = defaultIfBlank(req.getParameter("format"), "csv");
+            ExportFile file = moApplicationExportService.buildExport(getServletContext(), moId, jobId, scope, format);
+
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setContentType(file.getContentType());
+            resp.setHeader("Content-Disposition", "attachment; filename=\"" + file.getFileName() + "\"");
+            resp.setContentLength(file.getContent().length);
+            resp.getOutputStream().write(file.getContent());
+        } catch (MoBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+
+    private String defaultIfBlank(String value, String defaultValue) {
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}

--- a/web/src/main/java/com/ta/web/mo/MoJobHistoryServlet.java
+++ b/web/src/main/java/com/ta/web/mo/MoJobHistoryServlet.java
@@ -1,0 +1,35 @@
+package com.ta.web.mo;
+
+import com.ta.constant.ErrorCodes;
+import com.ta.dto.mo.MoJobHistoryResponse;
+import com.ta.service.mo.MoBusinessException;
+import com.ta.service.mo.MoJobHistoryService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "MoJobHistoryServlet", urlPatterns = {"/api/mo/jobs/history"})
+public class MoJobHistoryServlet extends MoBaseServlet {
+    private final MoJobHistoryService moJobHistoryService = new MoJobHistoryService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            String moId = getMoIdFromSession(req);
+            if (moId == null || moId.isBlank()) {
+                writeError(resp, HttpServletResponse.SC_UNAUTHORIZED, ErrorCodes.UNAUTHORIZED, "MO login required.");
+                return;
+            }
+
+            MoJobHistoryResponse data = moJobHistoryService.listHistory(getServletContext(), moId);
+            writeSuccess(resp, data);
+        } catch (MoBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/ta/web/mo/MoJobReuseServlet.java
+++ b/web/src/main/java/com/ta/web/mo/MoJobReuseServlet.java
@@ -1,0 +1,41 @@
+package com.ta.web.mo;
+
+import com.ta.constant.ErrorCodes;
+import com.ta.dto.mo.MoDemandItemResponse;
+import com.ta.service.mo.MoBusinessException;
+import com.ta.service.mo.MoJobService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "MoJobReuseServlet", urlPatterns = {"/api/mo/jobs/reuse"})
+public class MoJobReuseServlet extends MoBaseServlet {
+    private final MoJobService moJobService = new MoJobService();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            String moId = getMoIdFromSession(req);
+            if (moId == null || moId.isBlank()) {
+                writeError(resp, HttpServletResponse.SC_UNAUTHORIZED, ErrorCodes.UNAUTHORIZED, "MO login required.");
+                return;
+            }
+
+            String jobId = req.getParameter("jobId");
+            if (jobId == null || jobId.isBlank()) {
+                writeError(resp, HttpServletResponse.SC_BAD_REQUEST, ErrorCodes.VALIDATION_ERROR, "jobId is required.");
+                return;
+            }
+
+            MoDemandItemResponse data = moJobService.reuseJob(getServletContext(), moId, jobId);
+            writeSuccess(resp, data);
+        } catch (MoBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/webapp/assets/js/teacher.js
+++ b/web/src/main/webapp/assets/js/teacher.js
@@ -70,6 +70,8 @@ function teacherSetButtonLoading(button, loadingText, fallbackText, isLoading) {
 
 const teacherState = {
   items: [],
+  historyItems: [],
+  currentHistoryJobId: null,
   pollingTimer: null,
   notifications: [],
   unreadCount: 0
@@ -99,6 +101,64 @@ async function loadTeacherJobs() {
   const data = await teacherRequest(`${teacherApiBase()}/demands/list`, { method: "GET" });
   teacherState.items = data && Array.isArray(data.items) ? data.items : [];
   renderTeacherJobs();
+}
+
+async function loadJobHistory() {
+  const data = await teacherRequest(`${teacherApiBase()}/jobs/history`, { method: "GET" });
+  teacherState.historyItems = data && Array.isArray(data.items) ? data.items : [];
+  renderJobHistory();
+}
+
+function historyStatusTag(status) {
+  const normalized = String(status || "").toLowerCase();
+  if (normalized === "recruitment_closed") return '<span class="mo-status-pill mo-status-withdrawn">recruitment closed</span>';
+  if (normalized === "withdrawn") return '<span class="mo-status-pill mo-status-withdrawn">withdrawn</span>';
+  if (normalized === "open" || normalized === "published") return '<span class="mo-status-pill mo-status-published">published</span>';
+  if (normalized === "approved") return '<span class="mo-status-pill mo-status-approved">approved</span>';
+  if (normalized === "rejected") return '<span class="mo-status-pill mo-status-rejected">rejected</span>';
+  return '<span class="mo-status-pill mo-status-pending">draft</span>';
+}
+
+function renderJobHistory() {
+  const body = byId("historyTableBody");
+  const empty = byId("historyEmpty");
+  const tableWrap = document.querySelector(".mo-history-table-wrap");
+
+  if (!teacherState.historyItems.length) {
+    body.innerHTML = "";
+    empty.style.display = "block";
+    if (tableWrap) tableWrap.style.display = "none";
+    return;
+  }
+
+  empty.style.display = "none";
+  if (tableWrap) tableWrap.style.display = "block";
+  body.innerHTML = teacherState.historyItems.map((item) => renderHistoryRow(item)).join("");
+}
+
+function renderHistoryRow(item) {
+  const jobId = teacherEscapeHtml(teacherSafeText(item.jobId));
+  return `
+    <tr data-history-job-id="${jobId}">
+      <td>
+        <strong>${teacherEscapeHtml(teacherSafeText(item.courseName))}</strong>
+        <div style="font-size:12px;color:#64748b">${teacherEscapeHtml(teacherSafeText(item.department))}</div>
+      </td>
+      <td>${historyStatusTag(item.status)}</td>
+      <td><span class="mo-history-counts"><span>${teacherEscapeHtml(teacherSafeText(item.applicantCount))}</span></span></td>
+      <td><span class="mo-history-counts"><span>${teacherEscapeHtml(teacherSafeText(item.hireCount))}</span></span></td>
+      <td>${teacherEscapeHtml(teacherFormatDateTime(item.releaseTime))}</td>
+      <td>${teacherEscapeHtml(teacherSafeText(item.deadline))}</td>
+      <td>
+        <div class="mo-history-actions">
+          <button class="btn btn-outline" type="button" data-history-details="${jobId}">View Details</button>
+          <button class="btn btn-outline" type="button" data-history-reuse="${jobId}">Reuse</button>
+          <button class="btn btn-outline" type="button" data-history-export="${jobId}" data-scope="all" data-format="csv">Export All</button>
+          <button class="btn btn-outline" type="button" data-history-export="${jobId}" data-scope="shortlisted" data-format="csv">Export Shortlisted</button>
+        </div>
+      </td>
+    </tr>
+  `;
 }
 
 function renderTeacherJobs() {
@@ -404,6 +464,148 @@ async function markNotificationRead(notificationId) {
   await loadNotifications();
 }
 
+async function changeTeacherPassword(event) {
+  event.preventDefault();
+  const button = byId("teacherChangePasswordBtn");
+  teacherSetButtonLoading(button, "Changing...", "Change Password", true);
+  try {
+    await teacherRequest(`${accountApiBase()}/change-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=UTF-8" },
+      body: JSON.stringify({
+        oldPassword: byId("teacherOldPassword").value.trim(),
+        newPassword: byId("teacherNewPassword").value.trim(),
+        confirmPassword: byId("teacherConfirmPassword").value.trim()
+      })
+    });
+    byId("teacherChangePasswordForm").reset();
+    teacherSetNotice("globalNotice", "Password changed successfully.", false);
+  } catch (err) {
+    teacherSetNotice("globalNotice", `${err.code || "REQUEST_ERROR"}: ${err.message}`, true);
+  } finally {
+    teacherSetButtonLoading(button, "Changing...", "Change Password", false);
+  }
+}
+
+function exportApplicants(jobId, scope, format) {
+  const params = new URLSearchParams({ jobId, scope, format });
+  window.location.href = `${teacherApiBase()}/applications/export?${params.toString()}`;
+}
+
+async function reuseHistoryJob(jobId, button) {
+  if (!window.confirm("Create a new draft job by reusing this historical job?")) {
+    return;
+  }
+  teacherSetButtonLoading(button, "Reusing...", "Reuse", true);
+  try {
+    const params = new URLSearchParams({ jobId });
+    const data = await teacherRequest(`${teacherApiBase()}/jobs/reuse?${params.toString()}`, { method: "POST" });
+    teacherSetNotice("historyNotice", `Created new draft job ${data.jobId}.`, false);
+    await loadTeacherJobs();
+    await loadJobHistory();
+  } catch (err) {
+    teacherSetNotice("historyNotice", `${err.code || "REQUEST_ERROR"}: ${err.message}`, true);
+  } finally {
+    teacherSetButtonLoading(button, "Reusing...", "Reuse", false);
+  }
+}
+
+async function openHistoryDetails(jobId) {
+  teacherState.currentHistoryJobId = jobId;
+  const item = teacherState.historyItems.find((it) => it.jobId === jobId);
+  byId("historyDetailsTitle").textContent = item ? teacherSafeText(item.courseName) : "Job Details";
+  byId("historyDetailsSubtitle").textContent = `Job ID: ${jobId}`;
+  byId("historyDetailsBody").innerHTML = "";
+  byId("historyDetailsModal").classList.add("open");
+  teacherSetNotice("historyDetailsNotice", "Loading applicants...", false);
+
+  try {
+    const params = new URLSearchParams({ jobId });
+    const data = await teacherRequest(`${teacherApiBase()}/applications?${params.toString()}`, { method: "GET" });
+    const items = data && Array.isArray(data.items) ? data.items : [];
+    renderHistoryDetails(items);
+    teacherSetNotice("historyDetailsNotice", `Loaded ${items.length} applicant record(s).`, false);
+  } catch (err) {
+    teacherSetNotice("historyDetailsNotice", `${err.code || "REQUEST_ERROR"}: ${err.message}`, true);
+  }
+}
+
+function renderHistoryDetails(items) {
+  const body = byId("historyDetailsBody");
+  if (!items.length) {
+    body.innerHTML = '<tr><td colspan="6" style="text-align:center;color:#64748b">No applicants for this job.</td></tr>';
+    return;
+  }
+  body.innerHTML = items.map((item) => `
+    <tr>
+      <td>${teacherEscapeHtml(teacherSafeText(item.studentName))}</td>
+      <td>${teacherEscapeHtml(teacherSafeText(item.studentNo || item.studentId))}</td>
+      <td>${teacherEscapeHtml(teacherSafeText(item.programme))}</td>
+      <td>${teacherEscapeHtml(teacherFormatDateTime(item.appliedAt))}</td>
+      <td>${teacherEscapeHtml(teacherSafeText(item.status))}</td>
+      <td>${teacherEscapeHtml(teacherSafeText(item.skills))}</td>
+    </tr>
+  `).join("");
+}
+
+function closeHistoryDetails() {
+  teacherState.currentHistoryJobId = null;
+  byId("historyDetailsModal").classList.remove("open");
+}
+
+function bindHistoryActions() {
+  byId("historyReloadBtn").addEventListener("click", reloadJobHistory);
+  byId("historyTableBody").addEventListener("click", async (event) => {
+    const detailsBtn = event.target.closest("[data-history-details]");
+    if (detailsBtn) {
+      await openHistoryDetails(detailsBtn.getAttribute("data-history-details"));
+      return;
+    }
+
+    const reuseBtn = event.target.closest("[data-history-reuse]");
+    if (reuseBtn) {
+      await reuseHistoryJob(reuseBtn.getAttribute("data-history-reuse"), reuseBtn);
+      return;
+    }
+
+    const exportBtn = event.target.closest("[data-history-export]");
+    if (exportBtn) {
+      exportApplicants(
+        exportBtn.getAttribute("data-history-export"),
+        exportBtn.getAttribute("data-scope") || "all",
+        exportBtn.getAttribute("data-format") || "csv"
+      );
+    }
+  });
+
+  byId("historyDetailsCloseBtn").addEventListener("click", closeHistoryDetails);
+  byId("historyDetailsModal").addEventListener("click", (event) => {
+    if (event.target.id === "historyDetailsModal") closeHistoryDetails();
+  });
+  byId("modalExportAllCsvBtn").addEventListener("click", () => {
+    if (teacherState.currentHistoryJobId) exportApplicants(teacherState.currentHistoryJobId, "all", "csv");
+  });
+  byId("modalExportShortlistedCsvBtn").addEventListener("click", () => {
+    if (teacherState.currentHistoryJobId) exportApplicants(teacherState.currentHistoryJobId, "shortlisted", "csv");
+  });
+  byId("modalExportAllJsonBtn").addEventListener("click", () => {
+    if (teacherState.currentHistoryJobId) exportApplicants(teacherState.currentHistoryJobId, "all", "json");
+  });
+  byId("modalExportShortlistedJsonBtn").addEventListener("click", () => {
+    if (teacherState.currentHistoryJobId) exportApplicants(teacherState.currentHistoryJobId, "shortlisted", "json");
+  });
+}
+
+async function reloadJobHistory() {
+  try {
+    teacherSetNotice("historyNotice", "Loading job history...", false);
+    await loadJobHistory();
+    teacherSetNotice("historyNotice", `Loaded ${teacherState.historyItems.length} historical job record(s).`, false);
+  } catch (err) {
+    teacherSetNotice("historyNotice", `${err.code || "REQUEST_ERROR"}: ${err.message}`, true);
+  }
+}
+
 function bindTeacherFeedActions() {
   const feed = byId("jobsFeed");
   feed.addEventListener("click", async event => {
@@ -464,6 +666,7 @@ async function reloadTeacherWorkflow() {
   try {
     teacherSetNotice("jobsNotice", "Loading demand list...", false);
     await loadTeacherJobs();
+    await loadJobHistory();
     teacherSetNotice("jobsNotice", `Loaded ${teacherState.items.length} job record(s).`, false);
   } catch (err) {
     teacherSetNotice("jobsNotice", `${err.code || "REQUEST_ERROR"}: ${err.message}`, true);
@@ -483,6 +686,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     await markNotificationRead(markBtn.getAttribute("data-mark-read"));
   });
   bindTeacherFeedActions();
+  bindHistoryActions();
   await reloadTeacherWorkflow();
   await loadNotifications();
 });

--- a/web/src/main/webapp/pages/teacher.jsp
+++ b/web/src/main/webapp/pages/teacher.jsp
@@ -169,6 +169,123 @@
     .mo-notification-item:last-child {
       border-bottom: none;
     }
+    .mo-history-card {
+      margin-top: 18px;
+    }
+    .mo-history-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 12px;
+    }
+    .mo-history-table-wrap {
+      overflow-x: auto;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      background: #fff;
+    }
+    .mo-history-table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 920px;
+    }
+    .mo-history-table th,
+    .mo-history-table td {
+      padding: 12px 14px;
+      border-bottom: 1px solid #e5e7eb;
+      text-align: left;
+      vertical-align: top;
+      font-size: 14px;
+    }
+    .mo-history-table th {
+      background: #f8fafc;
+      color: #334155;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: .03em;
+    }
+    .mo-history-table tr:last-child td {
+      border-bottom: none;
+    }
+    .mo-history-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .mo-history-actions .btn {
+      padding: 6px 10px;
+      font-size: 12px;
+    }
+    .mo-history-counts {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .mo-history-counts span {
+      border-radius: 999px;
+      padding: 3px 8px;
+      background: #f1f5f9;
+      color: #334155;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .mo-modal-mask {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(15, 23, 42, 0.45);
+      z-index: 1000;
+      padding: 20px;
+    }
+    .mo-modal-mask.open {
+      display: flex;
+    }
+    .mo-modal {
+      width: min(980px, 96vw);
+      max-height: 88vh;
+      overflow: auto;
+      border-radius: 14px;
+      background: #fff;
+      border: 1px solid #dbe2ee;
+      box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+      padding: 18px;
+    }
+    .mo-modal-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .mo-modal-head h3 {
+      margin: 0 0 4px;
+    }
+    .mo-details-table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 780px;
+    }
+    .mo-details-table th,
+    .mo-details-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid #e5e7eb;
+      text-align: left;
+      font-size: 13px;
+      vertical-align: top;
+    }
+    .mo-details-table th {
+      background: #f8fafc;
+      color: #334155;
+    }
+    .mo-table-scroll {
+      overflow-x: auto;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+    }
     @media (max-width: 960px) {
       .mo-job-layout {
         grid-template-columns: 1fr;
@@ -273,6 +390,67 @@
       <div id="jobsFeed"></div>
     </div>
   </section>
+  <section class="card mo-history-card">
+    <div class="mo-history-head">
+      <div>
+        <h3>Job History</h3>
+        <p class="desc">Review released jobs, applicant statistics, reuse previous job settings, and export applicant data.</p>
+      </div>
+      <button id="historyReloadBtn" class="btn btn-outline" type="button">Refresh History</button>
+    </div>
+    <div id="historyNotice" class="notice"></div>
+    <div id="historyEmpty" class="mo-empty-tip" style="display:none;">No job history found yet.</div>
+    <div class="mo-history-table-wrap">
+      <table class="mo-history-table" aria-label="Job history table">
+        <thead>
+          <tr>
+            <th>Job Title</th>
+            <th>Status</th>
+            <th>Applicants</th>
+            <th>Hired</th>
+            <th>Release Time</th>
+            <th>Deadline</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody id="historyTableBody"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <div id="historyDetailsModal" class="mo-modal-mask" role="dialog" aria-modal="true" aria-labelledby="historyDetailsTitle">
+    <div class="mo-modal">
+      <div class="mo-modal-head">
+        <div>
+          <h3 id="historyDetailsTitle">Job Details</h3>
+          <p id="historyDetailsSubtitle" class="desc"></p>
+        </div>
+        <button id="historyDetailsCloseBtn" class="btn btn-outline" type="button">Close</button>
+      </div>
+      <div id="historyDetailsNotice" class="notice"></div>
+      <div class="row" style="margin-bottom:12px;">
+        <button id="modalExportAllCsvBtn" class="btn btn-outline" type="button">Export All CSV</button>
+        <button id="modalExportShortlistedCsvBtn" class="btn btn-outline" type="button">Export Shortlisted CSV</button>
+        <button id="modalExportAllJsonBtn" class="btn btn-outline" type="button">Export All JSON</button>
+        <button id="modalExportShortlistedJsonBtn" class="btn btn-outline" type="button">Export Shortlisted JSON</button>
+      </div>
+      <div class="mo-table-scroll">
+        <table class="mo-details-table" aria-label="Applicant detail table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Applicant ID</th>
+              <th>Major</th>
+              <th>Application Time</th>
+              <th>Status</th>
+              <th>Skills</th>
+            </tr>
+          </thead>
+          <tbody id="historyDetailsBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 </main>
 <script src="../assets/js/common.js?v=mo3"></script>
 <script src="../assets/js/teacher.js?v=mo3"></script>


### PR DESCRIPTION
Description:
This update implements the Module Organiser job history and applicant export workflow.
Changes:
- Added publishedAt to job postings for release-time tracking.
- Added MO job history API with applicant count and hired count aggregation.
- Added Job History table to the MO portal.
- Added View Details modal for historical job applicant records.
- Added Reuse action to clone a historical job into a new draft job.
- Added applicant export API supporting CSV and JSON formats.
- Added Export All and Export Shortlisted actions.
- CSV export uses UTF-8 BOM and includes the required columns:
  name, applicant_id, major, application_time, status, skills.
Testing:
- Verified Maven build succeeds.
- Verified Job History list loads correctly.
- Verified View Details displays applicant records.
- Verified Reuse creates a new draft job.
- Verified Export All downloads applicant data.
- Verified Export Shortlisted filters shortlisted applicants.
