### PR TITLE
feat(admin): add demand review and filtered exports

### DIFF
--- a/Function_Details.md
+++ b/Function_Details.md
@@ -613,8 +613,10 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - `AdminWorkloadSettingsServlet` (`GET/POST /api/admin/settings/workload-threshold`) remains responsible for loading and saving the overload threshold.
   - `AdminRecruitmentReportExportServlet` (`GET /api/admin/reports/weekly?format=csv|txt`) remains responsible for downloadable weekly recruitment summaries.
   - `AdminApplicationsServlet` (`GET /api/admin/applications`) provides read-only application archive rows for administrator audit.
-  - Future export routes may be added under `/api/admin/reports/*` for workload, applications, or backup files, but they must follow the same admin-only guard.
-  - Future alert routes may be added under `/api/admin/alerts` if alerts become independent from the dashboard response.
+  - `AdminWorkloadReportExportServlet` (`GET /api/admin/reports/workload?format=csv|txt`) exports workload rows and assigned job details.
+  - `AdminApplicationArchiveExportServlet` (`GET /api/admin/reports/applications?format=csv|txt`) exports the read-only application archive.
+  - `AdminBackupExportServlet` (`GET /api/admin/reports/backup`) exports a JSON backup bundle for the current file-based data.
+  - Administrator alerts are returned through `GET /api/admin/dashboard` so the overview and alert panel share one data source.
 
 - **Service Layer:**
   - `AdminDashboardService` computes overview statistics, job health fields, workload rows, and risk labels from `jobs.json`, `applications.json`, `users.json`, and `students.json`.

--- a/Function_Details.md
+++ b/Function_Details.md
@@ -557,6 +557,9 @@ The feature provides a dedicated view of accepted jobs, associated schedule info
 - **ADM_11:** As an Admin, I want to view and filter an application archive, so that I can audit recruitment decisions and preserve hiring records after recruitment is complete.
 - **ADM_12:** As an Admin, I want to export and back up recruitment data in simple file formats, so that the school can keep offline records and share summaries with management.
 - **ADM_13:** As an Admin, I want to receive system alerts for risky or incomplete recruitment situations, so that I can follow up with Module Organisers before issues affect TA allocation.
+- **ADM_14:** As an Admin, I want a demand approval workbench, so that newly submitted Module Organiser TA demands are visible and can be approved or rejected from one place.
+- **ADM_15:** As an Admin, I want to drill down from a job to its applications, so that I can audit applicant status and MO notes for a specific post without leaving the administrator portal.
+- **ADM_16:** As an Admin, I want recruitment exports to respect the current job filters, so that exported reports match what is shown on screen.
 
 **Description:**
 This Sprint 4 administrator extension builds on the Sprint 2 and Sprint 3 admin dashboard. Sprint 2 provides the baseline dashboard and account management. Sprint 3 adds workload threshold settings, department/status filtering, reports, and shared account maintenance. Sprint 4 refines the administrator role into a stronger monitoring and audit role.
@@ -606,6 +609,25 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
    - Alerts can be shown as dashboard cards or a dedicated alert panel.
    - If no alerts exist, the page shows a clear "No alerts" state.
 
+7. **Demand approval workbench**
+   - The admin can view demand records by approval status, especially newly submitted `pending` demands.
+   - Demand rows show module code, title, submitting organiser, submitted time, planned count, hour range, demand notes where provided, and current approval status.
+   - The admin can approve a pending demand, after which the MO can publish it through the existing publish workflow.
+   - The admin can reject a pending demand and optionally provide a short rejection reason.
+   - Rejected demand reasons are persisted and visible to the submitting MO in the demand progress view.
+
+8. **Single-job application drilldown**
+   - Each admin job row or card provides a read-only "View Applications" action.
+   - The drilldown shows only applications for the selected job, including applicant name, student number, applied time, status, evaluation notes, and decision feedback.
+   - The drilldown can be filtered by application status without changing the global application archive.
+   - The admin can export the selected job's application rows in CSV or TXT format.
+
+9. **Filtered weekly export**
+   - Weekly recruitment report exports include the same `status` and `department` filters used by the jobs dashboard.
+   - Exporting with no filters or `all` filters still produces the full report.
+   - Export file names include the selected filter scope and export date where possible.
+   - Invalid filter or format values return a validation error instead of a misleading report.
+
 **Functional Requirement Details:**
 
 - **Servlet Implementation:**
@@ -613,14 +635,17 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - `AdminWorkloadSettingsServlet` (`GET/POST /api/admin/settings/workload-threshold`) remains responsible for loading and saving the overload threshold.
   - `AdminRecruitmentReportExportServlet` (`GET /api/admin/reports/weekly?format=csv|txt`) remains responsible for downloadable weekly recruitment summaries.
   - `AdminApplicationsServlet` (`GET /api/admin/applications`) provides read-only application archive rows for administrator audit.
+  - `AdminDemandsServlet` (`GET /api/admin/demands?status=pending|approved|rejected|all`) provides the administrator demand approval workbench data.
+  - `AdminDemandReviewServlet` (`POST /api/admin/demands/review/{jobId}?action=approve|reject`) approves or rejects pending demand records; reject accepts an optional JSON body containing `reason`.
   - `AdminWorkloadReportExportServlet` (`GET /api/admin/reports/workload?format=csv|txt`) exports workload rows and assigned job details.
-  - `AdminApplicationArchiveExportServlet` (`GET /api/admin/reports/applications?format=csv|txt`) exports the read-only application archive.
+  - `AdminApplicationArchiveExportServlet` (`GET /api/admin/reports/applications?format=csv|txt&jobId=&status=`) exports the read-only application archive or a single job's filtered application rows.
   - `AdminBackupExportServlet` (`GET /api/admin/reports/backup`) exports a JSON backup bundle for the current file-based data.
   - Administrator alerts are returned through `GET /api/admin/dashboard` so the overview and alert panel share one data source.
 
 - **Service Layer:**
   - `AdminDashboardService` computes overview statistics, job health fields, workload rows, and risk labels from `jobs.json`, `applications.json`, `users.json`, and `students.json`.
-  - `AdminReportService` prepares CSV and TXT export content using the same job and application aggregation rules as the dashboard.
+  - `AdminDemandReviewService` lists demand records and applies approval or rejection decisions while preserving MO-owned job publishing rules.
+  - `AdminReportService` prepares CSV and TXT export content using the same job and application aggregation rules as the dashboard, including current job filters for weekly reports.
   - Application archive logic reads existing `ApplicationRecord` fields without changing MO-owned decision data.
   - Workload calculation must reuse the shared weekly-hours rule:
     - if `job.hours > 0`, use `hours`;
@@ -628,15 +653,15 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
     - otherwise, use `0`.
 
 - **Data Management:**
-  - `jobs.json` stores job lifecycle, department, schedule, organiser, position, deadline, and workload fields.
+  - `jobs.json` stores job lifecycle, department, schedule, organiser, position, deadline, workload, approval review time, and optional rejection reason fields.
   - `applications.json` stores application status, active flag, timestamps, evaluation notes, decision feedback, and hiring status.
   - `users.json` and `students.json` provide user and student profile details needed for dashboard labels.
   - `system_settings.json` stores administrator-configured workload settings.
   - Sprint 4 admin features must remain compatible with old JSON records that do not contain newer optional fields such as `department`, `schedule`, or decision feedback.
 
 - **Frontend Integration:**
-  - `admin.jsp` provides separate dashboard areas for overview, workload, users, jobs, reports, archive, and alerts where implemented.
-  - `admin.js` loads dashboard data, applies status/department/organiser filters, renders workload level cards, and triggers CSV/TXT export downloads.
+  - `admin.jsp` provides separate dashboard areas for overview, workload, users, jobs, demand review, archive, and alerts where implemented.
+  - `admin.js` loads dashboard data, applies status/department/organiser filters, renders workload level cards, handles demand approval actions, opens single-job application drilldowns, and triggers CSV/TXT export downloads.
   - Workload UI must show level labels, weekly hours, assigned positions, and a legend matching backend classification.
   - Job cards should display business-friendly recruitment health information instead of only raw table columns.
   - Empty states must be explicit for no jobs, no workload records, no archived applications, and no alerts.
@@ -647,6 +672,8 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - Archive and report APIs are read-only and must not change job status, application status, or MO feedback.
   - Filters must be optional; when no filter is supplied, the dashboard returns the full admin-visible dataset.
   - Invalid export formats must return a clear validation error instead of generating an ambiguous file.
+  - Only `pending` demand records can be approved or rejected.
+  - Rejection reason text is optional but must remain short enough for display in the MO demand progress view.
 
 - **Session / Access Control:**
   - Non-admin users must be rejected from `/api/admin/*`.

--- a/web/src/main/java/com/ta/dto/admin/AdminApplicationArchiveItemResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminApplicationArchiveItemResponse.java
@@ -1,0 +1,139 @@
+package com.ta.dto.admin;
+
+public class AdminApplicationArchiveItemResponse {
+    private String applicationId;
+    private String jobId;
+    private String moduleCode;
+    private String title;
+    private String teacherName;
+    private String department;
+    private String studentId;
+    private String studentNo;
+    private String studentName;
+    private String programme;
+    private String status;
+    private String appliedAt;
+    private Boolean active;
+    private String evaluationNotes;
+    private String decisionFeedback;
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getModuleCode() {
+        return moduleCode;
+    }
+
+    public void setModuleCode(String moduleCode) {
+        this.moduleCode = moduleCode;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTeacherName() {
+        return teacherName;
+    }
+
+    public void setTeacherName(String teacherName) {
+        this.teacherName = teacherName;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getStudentId() {
+        return studentId;
+    }
+
+    public void setStudentId(String studentId) {
+        this.studentId = studentId;
+    }
+
+    public String getStudentNo() {
+        return studentNo;
+    }
+
+    public void setStudentNo(String studentNo) {
+        this.studentNo = studentNo;
+    }
+
+    public String getStudentName() {
+        return studentName;
+    }
+
+    public void setStudentName(String studentName) {
+        this.studentName = studentName;
+    }
+
+    public String getProgramme() {
+        return programme;
+    }
+
+    public void setProgramme(String programme) {
+        this.programme = programme;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getAppliedAt() {
+        return appliedAt;
+    }
+
+    public void setAppliedAt(String appliedAt) {
+        this.appliedAt = appliedAt;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public String getEvaluationNotes() {
+        return evaluationNotes;
+    }
+
+    public void setEvaluationNotes(String evaluationNotes) {
+        this.evaluationNotes = evaluationNotes;
+    }
+
+    public String getDecisionFeedback() {
+        return decisionFeedback;
+    }
+
+    public void setDecisionFeedback(String decisionFeedback) {
+        this.decisionFeedback = decisionFeedback;
+    }
+}

--- a/web/src/main/java/com/ta/dto/admin/AdminApplicationArchiveResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminApplicationArchiveResponse.java
@@ -1,0 +1,16 @@
+package com.ta.dto.admin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminApplicationArchiveResponse {
+    private List<AdminApplicationArchiveItemResponse> items = new ArrayList<>();
+
+    public List<AdminApplicationArchiveItemResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<AdminApplicationArchiveItemResponse> items) {
+        this.items = items == null ? new ArrayList<>() : items;
+    }
+}

--- a/web/src/main/java/com/ta/dto/admin/AdminDashboardAlertResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDashboardAlertResponse.java
@@ -1,0 +1,85 @@
+package com.ta.dto.admin;
+
+public class AdminDashboardAlertResponse {
+    private String id;
+    private String type;
+    private String severity;
+    private String title;
+    private String message;
+    private String targetType;
+    private String targetId;
+    private String ownerName;
+    private String dueDate;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(String severity) {
+        this.severity = severity;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getTargetType() {
+        return targetType;
+    }
+
+    public void setTargetType(String targetType) {
+        this.targetType = targetType;
+    }
+
+    public String getTargetId() {
+        return targetId;
+    }
+
+    public void setTargetId(String targetId) {
+        this.targetId = targetId;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(String dueDate) {
+        this.dueDate = dueDate;
+    }
+}

--- a/web/src/main/java/com/ta/dto/admin/AdminDashboardJobItemResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDashboardJobItemResponse.java
@@ -10,7 +10,12 @@ public class AdminDashboardJobItemResponse {
     private Integer positions;
     private Integer applicantCount;
     private Integer hiredCount;
+    private Integer unfilledCount;
     private Integer weeklyHours;
+    private Integer daysUntilDeadline;
+    private String healthLevel;
+    private String healthLabel;
+    private String filledLabel;
     private String deadline;
     private String publishedAt;
     private String createdAt;
@@ -92,12 +97,52 @@ public class AdminDashboardJobItemResponse {
         this.hiredCount = hiredCount;
     }
 
+    public Integer getUnfilledCount() {
+        return unfilledCount;
+    }
+
+    public void setUnfilledCount(Integer unfilledCount) {
+        this.unfilledCount = unfilledCount;
+    }
+
     public Integer getWeeklyHours() {
         return weeklyHours;
     }
 
     public void setWeeklyHours(Integer weeklyHours) {
         this.weeklyHours = weeklyHours;
+    }
+
+    public Integer getDaysUntilDeadline() {
+        return daysUntilDeadline;
+    }
+
+    public void setDaysUntilDeadline(Integer daysUntilDeadline) {
+        this.daysUntilDeadline = daysUntilDeadline;
+    }
+
+    public String getHealthLevel() {
+        return healthLevel;
+    }
+
+    public void setHealthLevel(String healthLevel) {
+        this.healthLevel = healthLevel;
+    }
+
+    public String getHealthLabel() {
+        return healthLabel;
+    }
+
+    public void setHealthLabel(String healthLabel) {
+        this.healthLabel = healthLabel;
+    }
+
+    public String getFilledLabel() {
+        return filledLabel;
+    }
+
+    public void setFilledLabel(String filledLabel) {
+        this.filledLabel = filledLabel;
     }
 
     public String getDeadline() {

--- a/web/src/main/java/com/ta/dto/admin/AdminDashboardResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDashboardResponse.java
@@ -7,9 +7,22 @@ public class AdminDashboardResponse {
     private int totalJobs;
     private int totalUsers;
     private int totalApplications;
+    private int totalStudents;
+    private int totalTeachers;
+    private int totalAdmins;
+    private int totalActiveJobs;
+    private int totalClosedJobs;
+    private int totalDraftJobs;
+    private int totalWithdrawnJobs;
+    private int totalHiredRecords;
+    private int totalUnfilledPositions;
+    private int totalOpenApplications;
+    private int totalWarningStudents;
+    private int totalOverloadedStudents;
     private List<AdminDashboardUserItemResponse> users = new ArrayList<>();
     private List<AdminDashboardJobItemResponse> jobs = new ArrayList<>();
     private List<AdminDashboardWorkloadItemResponse> workload = new ArrayList<>();
+    private List<AdminDashboardAlertResponse> alerts = new ArrayList<>();
 
     public int getTotalJobs() {
         return totalJobs;
@@ -35,6 +48,102 @@ public class AdminDashboardResponse {
         this.totalApplications = totalApplications;
     }
 
+    public int getTotalStudents() {
+        return totalStudents;
+    }
+
+    public void setTotalStudents(int totalStudents) {
+        this.totalStudents = totalStudents;
+    }
+
+    public int getTotalTeachers() {
+        return totalTeachers;
+    }
+
+    public void setTotalTeachers(int totalTeachers) {
+        this.totalTeachers = totalTeachers;
+    }
+
+    public int getTotalAdmins() {
+        return totalAdmins;
+    }
+
+    public void setTotalAdmins(int totalAdmins) {
+        this.totalAdmins = totalAdmins;
+    }
+
+    public int getTotalActiveJobs() {
+        return totalActiveJobs;
+    }
+
+    public void setTotalActiveJobs(int totalActiveJobs) {
+        this.totalActiveJobs = totalActiveJobs;
+    }
+
+    public int getTotalClosedJobs() {
+        return totalClosedJobs;
+    }
+
+    public void setTotalClosedJobs(int totalClosedJobs) {
+        this.totalClosedJobs = totalClosedJobs;
+    }
+
+    public int getTotalDraftJobs() {
+        return totalDraftJobs;
+    }
+
+    public void setTotalDraftJobs(int totalDraftJobs) {
+        this.totalDraftJobs = totalDraftJobs;
+    }
+
+    public int getTotalWithdrawnJobs() {
+        return totalWithdrawnJobs;
+    }
+
+    public void setTotalWithdrawnJobs(int totalWithdrawnJobs) {
+        this.totalWithdrawnJobs = totalWithdrawnJobs;
+    }
+
+    public int getTotalHiredRecords() {
+        return totalHiredRecords;
+    }
+
+    public void setTotalHiredRecords(int totalHiredRecords) {
+        this.totalHiredRecords = totalHiredRecords;
+    }
+
+    public int getTotalUnfilledPositions() {
+        return totalUnfilledPositions;
+    }
+
+    public void setTotalUnfilledPositions(int totalUnfilledPositions) {
+        this.totalUnfilledPositions = totalUnfilledPositions;
+    }
+
+    public int getTotalOpenApplications() {
+        return totalOpenApplications;
+    }
+
+    public void setTotalOpenApplications(int totalOpenApplications) {
+        this.totalOpenApplications = totalOpenApplications;
+    }
+
+    public int getTotalWarningStudents() {
+        return totalWarningStudents;
+    }
+
+    public void setTotalWarningStudents(int totalWarningStudents) {
+        this.totalWarningStudents = totalWarningStudents;
+    }
+
+    public int getTotalOverloadedStudents() {
+        return totalOverloadedStudents;
+    }
+
+    public void setTotalOverloadedStudents(int totalOverloadedStudents) {
+        this.totalOverloadedStudents = totalOverloadedStudents;
+    }
+
     public List<AdminDashboardUserItemResponse> getUsers() {
         return users;
     }
@@ -57,5 +166,13 @@ public class AdminDashboardResponse {
 
     public void setWorkload(List<AdminDashboardWorkloadItemResponse> workload) {
         this.workload = workload;
+    }
+
+    public List<AdminDashboardAlertResponse> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<AdminDashboardAlertResponse> alerts) {
+        this.alerts = alerts == null ? new ArrayList<>() : alerts;
     }
 }

--- a/web/src/main/java/com/ta/dto/admin/AdminDemandItemResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDemandItemResponse.java
@@ -1,31 +1,27 @@
-package com.ta.dto.mo;
+package com.ta.dto.admin;
 
-/**
- * Demand list item for MO progress tracking.
- */
-public class MoDemandItemResponse {
+public class AdminDemandItemResponse {
     private String jobId;
     private String moId;
-    private String courseName;
+    private String teacherName;
+    private String moduleCode;
+    private String title;
     private String department;
     private Integer plannedCount;
     private Integer hourMin;
     private Integer hourMax;
-    /** Weekly hours from legacy job.hours when hourMin/hourMax absent */
     private Integer hours;
     private String approvalStatus;
     private String status;
     private Boolean published;
     private Boolean withdrawn;
     private Boolean recruitmentClosed;
-    private String closedAt;
     private String schedule;
     private String location;
     private String deadline;
     private String requirements;
     private String createdAt;
     private String updatedAt;
-    private String publishedAt;
     private String reviewedAt;
     private String rejectionReason;
 
@@ -45,12 +41,28 @@ public class MoDemandItemResponse {
         this.moId = moId;
     }
 
-    public String getCourseName() {
-        return courseName;
+    public String getTeacherName() {
+        return teacherName;
     }
 
-    public void setCourseName(String courseName) {
-        this.courseName = courseName;
+    public void setTeacherName(String teacherName) {
+        this.teacherName = teacherName;
+    }
+
+    public String getModuleCode() {
+        return moduleCode;
+    }
+
+    public void setModuleCode(String moduleCode) {
+        this.moduleCode = moduleCode;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 
     public String getDepartment() {
@@ -133,14 +145,6 @@ public class MoDemandItemResponse {
         this.recruitmentClosed = recruitmentClosed;
     }
 
-    public String getClosedAt() {
-        return closedAt;
-    }
-
-    public void setClosedAt(String closedAt) {
-        this.closedAt = closedAt;
-    }
-
     public String getSchedule() {
         return schedule;
     }
@@ -187,14 +191,6 @@ public class MoDemandItemResponse {
 
     public void setUpdatedAt(String updatedAt) {
         this.updatedAt = updatedAt;
-    }
-
-    public String getPublishedAt() {
-        return publishedAt;
-    }
-
-    public void setPublishedAt(String publishedAt) {
-        this.publishedAt = publishedAt;
     }
 
     public String getReviewedAt() {

--- a/web/src/main/java/com/ta/dto/admin/AdminDemandListResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDemandListResponse.java
@@ -1,0 +1,16 @@
+package com.ta.dto.admin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminDemandListResponse {
+    private List<AdminDemandItemResponse> items = new ArrayList<>();
+
+    public List<AdminDemandItemResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<AdminDemandItemResponse> items) {
+        this.items = items == null ? new ArrayList<>() : items;
+    }
+}

--- a/web/src/main/java/com/ta/dto/admin/AdminDemandReviewRequest.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDemandReviewRequest.java
@@ -1,0 +1,13 @@
+package com.ta.dto.admin;
+
+public class AdminDemandReviewRequest {
+    private String reason;
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/web/src/main/java/com/ta/dto/admin/AdminDemandReviewResponse.java
+++ b/web/src/main/java/com/ta/dto/admin/AdminDemandReviewResponse.java
@@ -7,6 +7,7 @@ public class AdminDemandReviewResponse {
     private Boolean published;
     private Boolean withdrawn;
     private String reviewedAt;
+    private String rejectionReason;
 
     public String getJobId() {
         return jobId;
@@ -54,5 +55,13 @@ public class AdminDemandReviewResponse {
 
     public void setReviewedAt(String reviewedAt) {
         this.reviewedAt = reviewedAt;
+    }
+
+    public String getRejectionReason() {
+        return rejectionReason;
+    }
+
+    public void setRejectionReason(String rejectionReason) {
+        this.rejectionReason = rejectionReason;
     }
 }

--- a/web/src/main/java/com/ta/dto/mo/MoDemandCreateRequest.java
+++ b/web/src/main/java/com/ta/dto/mo/MoDemandCreateRequest.java
@@ -9,6 +9,7 @@ public class MoDemandCreateRequest {
     private Integer plannedCount;
     private Integer hourMin;
     private Integer hourMax;
+    private String requirements;
 
     public String getCourseName() {
         return courseName;
@@ -48,5 +49,13 @@ public class MoDemandCreateRequest {
 
     public void setHourMax(Integer hourMax) {
         this.hourMax = hourMax;
+    }
+
+    public String getRequirements() {
+        return requirements;
+    }
+
+    public void setRequirements(String requirements) {
+        this.requirements = requirements;
     }
 }

--- a/web/src/main/java/com/ta/model/JobPosting.java
+++ b/web/src/main/java/com/ta/model/JobPosting.java
@@ -42,6 +42,10 @@ public class JobPosting {
     private Boolean recruitmentClosed;
     /** ISO timestamp when recruitment is closed. */
     private String closedAt;
+    /** Admin review timestamp for approval or rejection decisions. */
+    private String reviewedAt;
+    /** Optional short reason stored when an admin rejects a demand. */
+    private String rejectionReason;
     
 
     public JobPosting() {
@@ -229,5 +233,21 @@ public class JobPosting {
 
     public void setClosedAt(String closedAt) {
         this.closedAt = closedAt;
+    }
+
+    public String getReviewedAt() {
+        return reviewedAt;
+    }
+
+    public void setReviewedAt(String reviewedAt) {
+        this.reviewedAt = reviewedAt;
+    }
+
+    public String getRejectionReason() {
+        return rejectionReason;
+    }
+
+    public void setRejectionReason(String rejectionReason) {
+        this.rejectionReason = rejectionReason;
     }
 }

--- a/web/src/main/java/com/ta/service/admin/AdminApplicationArchiveService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminApplicationArchiveService.java
@@ -1,0 +1,151 @@
+package com.ta.service.admin;
+
+import com.ta.dto.admin.AdminApplicationArchiveItemResponse;
+import com.ta.dto.admin.AdminApplicationArchiveResponse;
+import com.ta.model.ApplicationRecord;
+import com.ta.model.JobPosting;
+import com.ta.model.StudentProfile;
+import com.ta.util.JsonUtility;
+import jakarta.servlet.ServletContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class AdminApplicationArchiveService {
+
+    public AdminApplicationArchiveResponse listArchive(ServletContext context,
+                                                        String statusFilter,
+                                                        String jobIdFilter,
+                                                        String teacherFilter,
+                                                        String studentFilter) {
+        try {
+            List<ApplicationRecord> applications = JsonUtility.loadApplications(context);
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            List<StudentProfile> students = JsonUtility.loadStudents(context);
+
+            Map<String, JobPosting> jobById = new LinkedHashMap<>();
+            for (JobPosting job : jobs) {
+                if (job.getId() != null) {
+                    jobById.put(job.getId(), job);
+                }
+            }
+
+            Map<String, StudentProfile> studentByUserId = new LinkedHashMap<>();
+            for (StudentProfile student : students) {
+                if (student.getUserId() != null) {
+                    studentByUserId.put(student.getUserId(), student);
+                }
+            }
+
+            String status = normalizeFilter(statusFilter);
+            String jobId = normalizeFilter(jobIdFilter);
+            String teacher = normalizeFilter(teacherFilter);
+            String student = normalizeFilter(studentFilter);
+
+            List<AdminApplicationArchiveItemResponse> items = new ArrayList<>();
+            for (ApplicationRecord application : applications) {
+                JobPosting job = jobById.get(application.getJobId());
+                StudentProfile profile = studentByUserId.get(application.getStudentId());
+                if (!matchesStatus(application, status)
+                        || !matchesJob(application, jobId)
+                        || !matchesTeacher(job, teacher)
+                        || !matchesStudent(application, profile, student)) {
+                    continue;
+                }
+                items.add(toItem(application, job, profile));
+            }
+
+            items.sort(Comparator
+                    .comparing(AdminApplicationArchiveItemResponse::getAppliedAt, Comparator.nullsLast(String::compareTo))
+                    .reversed());
+
+            AdminApplicationArchiveResponse response = new AdminApplicationArchiveResponse();
+            response.setItems(items);
+            return response;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load admin application archive.", e);
+        }
+    }
+
+    private AdminApplicationArchiveItemResponse toItem(ApplicationRecord application,
+                                                       JobPosting job,
+                                                       StudentProfile profile) {
+        AdminApplicationArchiveItemResponse item = new AdminApplicationArchiveItemResponse();
+        item.setApplicationId(application.getId());
+        item.setJobId(application.getJobId());
+        item.setStudentId(application.getStudentId());
+        item.setStudentNo(application.getStudentNo());
+        item.setStudentName(firstNonBlank(application.getStudentName(), profile == null ? "" : profile.getName()));
+        item.setProgramme(profile == null ? "" : profile.getProgramme());
+        item.setStatus(application.getStatus());
+        item.setAppliedAt(application.getAppliedAt());
+        item.setActive(application.isActive());
+        item.setEvaluationNotes(blankToEmpty(application.getEvaluationNotes()));
+        item.setDecisionFeedback(blankToEmpty(application.getDecisionFeedback()));
+        if (job != null) {
+            item.setModuleCode(job.getModuleCode());
+            item.setTitle(job.getTitle());
+            item.setTeacherName(job.getTeacherName());
+            item.setDepartment(job.getDepartment());
+        }
+        return item;
+    }
+
+    private boolean matchesStatus(ApplicationRecord application, String statusFilter) {
+        if ("all".equals(statusFilter)) {
+            return true;
+        }
+        return normalizeFilter(application.getStatus()).equals(statusFilter);
+    }
+
+    private boolean matchesJob(ApplicationRecord application, String jobIdFilter) {
+        if ("all".equals(jobIdFilter)) {
+            return true;
+        }
+        return normalizeFilter(application.getJobId()).equals(jobIdFilter);
+    }
+
+    private boolean matchesTeacher(JobPosting job, String teacherFilter) {
+        if ("all".equals(teacherFilter)) {
+            return true;
+        }
+        if (job == null) {
+            return false;
+        }
+        return normalizeFilter(job.getTeacherName()).equals(teacherFilter)
+                || normalizeFilter(job.getTeacherId()).equals(teacherFilter);
+    }
+
+    private boolean matchesStudent(ApplicationRecord application, StudentProfile profile, String studentFilter) {
+        if ("all".equals(studentFilter)) {
+            return true;
+        }
+        String normalized = studentFilter.toLowerCase(Locale.ROOT);
+        return contains(application.getStudentId(), normalized)
+                || contains(application.getStudentNo(), normalized)
+                || contains(application.getStudentName(), normalized)
+                || contains(profile == null ? "" : profile.getName(), normalized);
+    }
+
+    private boolean contains(String value, String normalizedNeedle) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(normalizedNeedle);
+    }
+
+    private String normalizeFilter(String value) {
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        return normalized.isBlank() || "all".equals(normalized) ? "all" : normalized;
+    }
+
+    private String firstNonBlank(String first, String second) {
+        return first != null && !first.isBlank() ? first : blankToEmpty(second);
+    }
+
+    private String blankToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/web/src/main/java/com/ta/service/admin/AdminDashboardService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminDashboardService.java
@@ -1,6 +1,7 @@
 package com.ta.service.admin;
 
 import com.ta.constant.ErrorCodes;
+import com.ta.dto.admin.AdminDashboardAlertResponse;
 import com.ta.dto.admin.AdminDashboardJobItemResponse;
 import com.ta.dto.admin.AdminDashboardResponse;
 import com.ta.dto.admin.AdminDashboardUserItemResponse;
@@ -17,6 +18,8 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -29,6 +32,7 @@ import java.util.Set;
 
 public class AdminDashboardService {
     private static final Set<String> ALLOWED_STATUS_FILTERS = Set.of("all", "draft", "open", "closed", "withdrawn");
+    private static final int DEADLINE_WARNING_DAYS = 7;
 
     public AdminDashboardResponse loadDashboard(ServletContext context, String statusFilter, String departmentFilter) {
         try {
@@ -41,18 +45,101 @@ public class AdminDashboardService {
             String normalizedStatus = normalizeStatusFilter(statusFilter);
             String normalizedDepartment = normalizeDepartmentFilter(jobs, departmentFilter);
             List<JobPosting> filteredJobs = filterJobs(jobs, normalizedStatus, normalizedDepartment);
+            List<AdminDashboardWorkloadItemResponse> workload = toWorkload(applications, jobs, settings.getWorkloadThresholdHours(), hiringHistory);
 
             AdminDashboardResponse data = new AdminDashboardResponse();
             data.setTotalUsers(users.size());
-            data.setTotalJobs(filteredJobs.size());
+            data.setTotalJobs(jobs.size());
             data.setTotalApplications((int) applications.stream().filter(ApplicationRecord::isActive).count());
+            populateOverview(data, users, jobs, applications, workload);
             data.setUsers(toUsers(users));
             data.setJobs(toJobs(filteredJobs, applications));
-            data.setWorkload(toWorkload(applications, jobs, settings.getWorkloadThresholdHours(), hiringHistory));
+            data.setWorkload(workload);
+            data.setAlerts(buildAlerts(jobs, applications, workload, settings.getWorkloadThresholdHours()));
             return data;
         } catch (IOException e) {
             throw new RuntimeException("Failed to load admin dashboard.", e);
         }
+    }
+
+    private void populateOverview(AdminDashboardResponse data,
+                                  List<User> users,
+                                  List<JobPosting> jobs,
+                                  List<ApplicationRecord> applications,
+                                  List<AdminDashboardWorkloadItemResponse> workload) {
+        int students = 0;
+        int teachers = 0;
+        int admins = 0;
+        for (User user : users) {
+            String role = trimToEmpty(user.getRole()).toLowerCase(Locale.ROOT);
+            if ("student".equals(role)) {
+                students++;
+            } else if ("teacher".equals(role)) {
+                teachers++;
+            } else if ("admin".equals(role)) {
+                admins++;
+            }
+        }
+
+        Map<String, Integer> hiredCountByJob = countHiredByJob(applications);
+        int activeJobs = 0;
+        int closedJobs = 0;
+        int draftJobs = 0;
+        int withdrawnJobs = 0;
+        int unfilledPositions = 0;
+        for (JobPosting job : jobs) {
+            if (Boolean.TRUE.equals(job.getWithdrawn())) {
+                withdrawnJobs++;
+                continue;
+            }
+            if (isClosed(job)) {
+                closedJobs++;
+            } else if ("draft".equalsIgnoreCase(trimToEmpty(job.getStatus()))) {
+                draftJobs++;
+            } else if ("open".equalsIgnoreCase(trimToEmpty(job.getStatus()))) {
+                activeJobs++;
+            }
+            unfilledPositions += Math.max(job.getPositions() - hiredCountByJob.getOrDefault(job.getId(), 0), 0);
+        }
+
+        int hiredRecords = 0;
+        int openApplications = 0;
+        for (ApplicationRecord application : applications) {
+            if (!application.isActive()) {
+                continue;
+            }
+            String status = trimToEmpty(application.getStatus()).toLowerCase(Locale.ROOT);
+            if ("hired".equals(status)) {
+                hiredRecords++;
+            }
+            if (Set.of("pending", "viewed", "shortlisted").contains(status)) {
+                openApplications++;
+            }
+        }
+
+        int warningStudents = 0;
+        int overloadedStudents = 0;
+        for (AdminDashboardWorkloadItemResponse item : workload) {
+            if ("warning".equalsIgnoreCase(item.getWorkloadLevel())) {
+                warningStudents++;
+            }
+            if ("overload".equalsIgnoreCase(item.getWorkloadLevel())) {
+                overloadedStudents++;
+            }
+        }
+
+        data.setTotalStudents(students);
+        data.setTotalTeachers(teachers);
+        data.setTotalAdmins(admins);
+        data.setTotalActiveJobs(activeJobs);
+        data.setTotalClosedJobs(closedJobs);
+        data.setTotalDraftJobs(draftJobs);
+        data.setTotalWithdrawnJobs(withdrawnJobs);
+        data.setTotalHiredRecords(hiredRecords);
+        data.setTotalOpenApplications(openApplications);
+        data.setTotalUnfilledPositions(unfilledPositions);
+        data.setTotalWarningStudents(warningStudents);
+        data.setTotalOverloadedStudents(overloadedStudents);
     }
 
     private String normalizeStatusFilter(String statusFilter) {
@@ -154,20 +241,15 @@ public class AdminDashboardService {
     }
 
     private List<AdminDashboardJobItemResponse> toJobs(List<JobPosting> jobs, List<ApplicationRecord> applications) {
-        Map<String, Integer> applicantCountByJob = new LinkedHashMap<>();
-        Map<String, Integer> hiredCountByJob = new LinkedHashMap<>();
-        for (ApplicationRecord app : applications) {
-            if (!app.isActive() || app.getJobId() == null || app.getJobId().isBlank()) {
-                continue;
-            }
-            applicantCountByJob.put(app.getJobId(), applicantCountByJob.getOrDefault(app.getJobId(), 0) + 1);
-            if ("hired".equalsIgnoreCase(app.getStatus())) {
-                hiredCountByJob.put(app.getJobId(), hiredCountByJob.getOrDefault(app.getJobId(), 0) + 1);
-            }
-        }
+        Map<String, Integer> applicantCountByJob = countApplicantsByJob(applications);
+        Map<String, Integer> hiredCountByJob = countHiredByJob(applications);
 
         List<AdminDashboardJobItemResponse> items = new ArrayList<>();
         for (JobPosting job : jobs) {
+            int positions = job.getPositions();
+            int applicantCount = applicantCountByJob.getOrDefault(job.getId(), 0);
+            int hiredCount = hiredCountByJob.getOrDefault(job.getId(), 0);
+            int unfilledCount = Math.max(positions - hiredCount, 0);
             AdminDashboardJobItemResponse item = new AdminDashboardJobItemResponse();
             item.setId(job.getId());
             item.setModuleCode(job.getModuleCode());
@@ -175,10 +257,14 @@ public class AdminDashboardService {
             item.setTeacherName(job.getTeacherName());
             item.setDepartment(job.getDepartment());
             item.setStatus(job.getStatus());
-            item.setPositions(job.getPositions());
-            item.setApplicantCount(applicantCountByJob.getOrDefault(job.getId(), 0));
-            item.setHiredCount(hiredCountByJob.getOrDefault(job.getId(), 0));
+            item.setPositions(positions);
+            item.setApplicantCount(applicantCount);
+            item.setHiredCount(hiredCount);
+            item.setUnfilledCount(unfilledCount);
+            item.setFilledLabel(hiredCount + "/" + positions + " Filled");
             item.setWeeklyHours(JobHoursUtil.resolveWeeklyHours(job));
+            item.setDaysUntilDeadline(resolveDaysUntilDeadline(job.getDeadline()));
+            applyJobHealth(item, job, applicantCount, unfilledCount);
             item.setDeadline(job.getDeadline());
             item.setPublishedAt(job.getPublishedAt());
             item.setCreatedAt(job.getCreatedAt());
@@ -246,6 +332,74 @@ public class AdminDashboardService {
         return items;
     }
 
+    private Map<String, Integer> countApplicantsByJob(List<ApplicationRecord> applications) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (ApplicationRecord app : applications) {
+            if (!app.isActive() || app.getJobId() == null || app.getJobId().isBlank()) {
+                continue;
+            }
+            counts.put(app.getJobId(), counts.getOrDefault(app.getJobId(), 0) + 1);
+        }
+        return counts;
+    }
+
+    private Map<String, Integer> countHiredByJob(List<ApplicationRecord> applications) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (ApplicationRecord app : applications) {
+            if (!app.isActive() || app.getJobId() == null || app.getJobId().isBlank()) {
+                continue;
+            }
+            if ("hired".equalsIgnoreCase(app.getStatus())) {
+                counts.put(app.getJobId(), counts.getOrDefault(app.getJobId(), 0) + 1);
+            }
+        }
+        return counts;
+    }
+
+    private void applyJobHealth(AdminDashboardJobItemResponse item,
+                                JobPosting job,
+                                int applicantCount,
+                                int unfilledCount) {
+        if (Boolean.TRUE.equals(job.getWithdrawn())) {
+            item.setHealthLevel("inactive");
+            item.setHealthLabel("Withdrawn");
+            return;
+        }
+        if (isClosed(job)) {
+            item.setHealthLevel(unfilledCount > 0 ? "closed-unfilled" : "complete");
+            item.setHealthLabel(unfilledCount > 0 ? "Closed with Vacancy" : "Complete");
+            return;
+        }
+        if (!"open".equalsIgnoreCase(trimToEmpty(job.getStatus()))) {
+            item.setHealthLevel("draft");
+            item.setHealthLabel("Draft");
+            return;
+        }
+        Integer days = item.getDaysUntilDeadline();
+        if (unfilledCount > 0 && days != null && days < 0) {
+            item.setHealthLevel("overdue");
+            item.setHealthLabel("Overdue Vacancy");
+            return;
+        }
+        if (unfilledCount > 0 && applicantCount == 0) {
+            item.setHealthLevel("no-applicants");
+            item.setHealthLabel("No Applicants");
+            return;
+        }
+        if (unfilledCount > 0 && days != null && days <= DEADLINE_WARNING_DAYS) {
+            item.setHealthLevel("deadline-risk");
+            item.setHealthLabel("Deadline Risk");
+            return;
+        }
+        if (unfilledCount > 0) {
+            item.setHealthLevel("unfilled");
+            item.setHealthLabel("Unfilled");
+            return;
+        }
+        item.setHealthLevel("healthy");
+        item.setHealthLabel("Filled");
+    }
+
     private AdminDashboardWorkloadJobResponse toWorkloadJob(JobPosting job,
                                                             int weeklyHours,
                                                             ApplicationRecord app,
@@ -265,7 +419,7 @@ public class AdminDashboardService {
         AdminDashboardWorkloadJobResponse row = new AdminDashboardWorkloadJobResponse();
         row.setApplicationId(app != null ? app.getId() : null);
         row.setJobId(app != null ? app.getJobId() : null);
-        row.setModuleCode("\u2014");
+        row.setModuleCode("-");
         String jobId = app != null ? trimToEmpty(app.getJobId()) : "";
         row.setTitle(jobId.isEmpty() ? "Job record missing" : "Job record missing (" + jobId + ")");
         row.setWeeklyHours(0);
@@ -335,6 +489,166 @@ public class AdminDashboardService {
         item.setWorkloadLevel("low");
         item.setWorkloadLabel("Low");
         item.setWarning(false);
+    }
+
+    private List<AdminDashboardAlertResponse> buildAlerts(List<JobPosting> jobs,
+                                                           List<ApplicationRecord> applications,
+                                                           List<AdminDashboardWorkloadItemResponse> workload,
+                                                           int threshold) {
+        List<AdminDashboardAlertResponse> alerts = new ArrayList<>();
+        for (AdminDashboardWorkloadItemResponse item : workload) {
+            if ("overload".equalsIgnoreCase(item.getWorkloadLevel())) {
+                alerts.add(alert(
+                        "workload-overload-" + safeId(item.getStudentId()),
+                        "workload",
+                        "danger",
+                        "Overloaded TA",
+                        item.getStudentName() + " has " + item.getWeeklyHours() + " hours/week, meeting or exceeding the " + threshold + "h threshold.",
+                        "student",
+                        item.getStudentId(),
+                        item.getStudentName(),
+                        null
+                ));
+            } else if ("warning".equalsIgnoreCase(item.getWorkloadLevel())) {
+                alerts.add(alert(
+                        "workload-warning-" + safeId(item.getStudentId()),
+                        "workload",
+                        "warning",
+                        "Workload warning",
+                        item.getStudentName() + " has " + item.getWeeklyHours() + " hours/week.",
+                        "student",
+                        item.getStudentId(),
+                        item.getStudentName(),
+                        null
+                ));
+            }
+        }
+
+        Map<String, Integer> applicantCountByJob = countApplicantsByJob(applications);
+        Map<String, Integer> hiredCountByJob = countHiredByJob(applications);
+        for (JobPosting job : jobs) {
+            if (Boolean.TRUE.equals(job.getWithdrawn()) || isClosed(job) || !"open".equalsIgnoreCase(trimToEmpty(job.getStatus()))) {
+                continue;
+            }
+            int applicants = applicantCountByJob.getOrDefault(job.getId(), 0);
+            int hired = hiredCountByJob.getOrDefault(job.getId(), 0);
+            int unfilled = Math.max(job.getPositions() - hired, 0);
+            Integer days = resolveDaysUntilDeadline(job.getDeadline());
+            String jobLabel = safeText(job.getModuleCode()) + " " + safeText(job.getTitle()).trim();
+            if (unfilled > 0 && applicants == 0) {
+                alerts.add(alert(
+                        "job-no-applicants-" + safeId(job.getId()),
+                        "recruitment",
+                        "warning",
+                        "Job has no applicants",
+                        jobLabel.trim() + " has " + unfilled + " unfilled position(s) and no active applicants.",
+                        "job",
+                        job.getId(),
+                        job.getTeacherName(),
+                        job.getDeadline()
+                ));
+            }
+            if (unfilled > 0 && days != null && days < 0) {
+                alerts.add(alert(
+                        "job-overdue-" + safeId(job.getId()),
+                        "deadline",
+                        "danger",
+                        "Deadline passed with vacancy",
+                        jobLabel.trim() + " still has " + unfilled + " unfilled position(s).",
+                        "job",
+                        job.getId(),
+                        job.getTeacherName(),
+                        job.getDeadline()
+                ));
+            } else if (unfilled > 0 && days != null && days <= DEADLINE_WARNING_DAYS) {
+                alerts.add(alert(
+                        "job-deadline-" + safeId(job.getId()),
+                        "deadline",
+                        "warning",
+                        "Deadline approaching",
+                        jobLabel.trim() + " has " + unfilled + " unfilled position(s) and " + days + " day(s) until deadline.",
+                        "job",
+                        job.getId(),
+                        job.getTeacherName(),
+                        job.getDeadline()
+                ));
+            }
+            if (trimToEmpty(job.getDepartment()).isBlank() || trimToEmpty(job.getSchedule()).isBlank()) {
+                alerts.add(alert(
+                        "job-incomplete-" + safeId(job.getId()),
+                        "data-quality",
+                        "info",
+                        "Incomplete job metadata",
+                        jobLabel.trim() + " is missing department or schedule data.",
+                        "job",
+                        job.getId(),
+                        job.getTeacherName(),
+                        job.getDeadline()
+                ));
+            }
+        }
+        alerts.sort(Comparator.comparingInt(this::severityRank).thenComparing(AdminDashboardAlertResponse::getTitle));
+        return alerts;
+    }
+
+    private AdminDashboardAlertResponse alert(String id,
+                                              String type,
+                                              String severity,
+                                              String title,
+                                              String message,
+                                              String targetType,
+                                              String targetId,
+                                              String ownerName,
+                                              String dueDate) {
+        AdminDashboardAlertResponse alert = new AdminDashboardAlertResponse();
+        alert.setId(id);
+        alert.setType(type);
+        alert.setSeverity(severity);
+        alert.setTitle(title);
+        alert.setMessage(message);
+        alert.setTargetType(targetType);
+        alert.setTargetId(targetId);
+        alert.setOwnerName(ownerName);
+        alert.setDueDate(dueDate);
+        return alert;
+    }
+
+    private int severityRank(AdminDashboardAlertResponse alert) {
+        String severity = trimToEmpty(alert.getSeverity()).toLowerCase(Locale.ROOT);
+        if ("danger".equals(severity)) {
+            return 0;
+        }
+        if ("warning".equals(severity)) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private boolean isClosed(JobPosting job) {
+        return Boolean.TRUE.equals(job.getRecruitmentClosed()) || "closed".equalsIgnoreCase(trimToEmpty(job.getStatus()));
+    }
+
+    private Integer resolveDaysUntilDeadline(String deadline) {
+        String value = trimToEmpty(deadline);
+        if (value.isBlank()) {
+            return null;
+        }
+        try {
+            String datePart = value.length() >= 10 ? value.substring(0, 10) : value;
+            LocalDate date = LocalDate.parse(datePart);
+            return (int) java.time.temporal.ChronoUnit.DAYS.between(LocalDate.now(), date);
+        } catch (DateTimeParseException | StringIndexOutOfBoundsException ex) {
+            return null;
+        }
+    }
+
+    private String safeId(String value) {
+        String safe = trimToEmpty(value);
+        return safe.isBlank() ? "unknown" : safe.replaceAll("[^A-Za-z0-9_-]", "_");
+    }
+
+    private String safeText(String value) {
+        return value == null ? "" : value + " ";
     }
 
     private String trimToEmpty(String value) {

--- a/web/src/main/java/com/ta/service/admin/AdminDemandReviewService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminDemandReviewService.java
@@ -1,21 +1,65 @@
 package com.ta.service.admin;
 
 import com.ta.constant.ErrorCodes;
+import com.ta.dto.admin.AdminDemandItemResponse;
+import com.ta.dto.admin.AdminDemandListResponse;
 import com.ta.dto.admin.AdminDemandReviewResponse;
 import com.ta.model.JobPosting;
+import com.ta.model.User;
 import com.ta.util.JsonUtility;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 public class AdminDemandReviewService {
+    private static final Set<String> ALLOWED_STATUS_FILTERS = Set.of("all", "pending", "approved", "rejected");
+    private static final int MAX_REJECTION_REASON_LENGTH = 200;
 
-    public AdminDemandReviewResponse reviewDemand(ServletContext context, String jobId, String action) {
+    public AdminDemandListResponse listDemands(ServletContext context, String statusFilter) {
+        String normalizedStatus = normalizeStatusFilter(statusFilter);
+        try {
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            List<User> users = JsonUtility.loadUsers(context);
+            Map<String, String> userNameById = new LinkedHashMap<>();
+            for (User user : users) {
+                if (user.getId() != null) {
+                    userNameById.put(user.getId(), user.getName());
+                }
+            }
+
+            List<AdminDemandItemResponse> items = new ArrayList<>();
+            for (JobPosting job : jobs) {
+                if (!isDemandRecord(job) || !matchesStatus(job, normalizedStatus)) {
+                    continue;
+                }
+                items.add(toDemandItem(job, userNameById));
+            }
+
+            items.sort(Comparator
+                    .comparing(AdminDemandItemResponse::getCreatedAt, Comparator.nullsLast(String::compareTo))
+                    .reversed());
+
+            AdminDemandListResponse response = new AdminDemandListResponse();
+            response.setItems(items);
+            return response;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load admin demand list.", e);
+        }
+    }
+
+    public AdminDemandReviewResponse reviewDemand(ServletContext context, String jobId, String action, String reason) {
         String normalizedAction = normalizeAction(action);
         String targetStatus = toApprovalStatus(normalizedAction);
+        String normalizedReason = normalizeReason(normalizedAction, reason);
 
         try {
             List<JobPosting> jobs = JsonUtility.loadJobs(context);
@@ -46,6 +90,8 @@ public class AdminDemandReviewService {
 
             String now = Instant.now().toString();
             job.setApprovalStatus(targetStatus);
+            job.setReviewedAt(now);
+            job.setRejectionReason("reject".equals(normalizedAction) ? normalizedReason : "");
             if (job.getPublished() == null) {
                 job.setPublished(false);
             }
@@ -63,10 +109,30 @@ public class AdminDemandReviewService {
             response.setPublished(job.getPublished());
             response.setWithdrawn(job.getWithdrawn());
             response.setReviewedAt(now);
+            response.setRejectionReason(job.getRejectionReason());
             return response;
         } catch (IOException e) {
             throw new RuntimeException("Failed to review demand.", e);
         }
+    }
+
+    public AdminDemandReviewResponse reviewDemand(ServletContext context, String jobId, String action) {
+        return reviewDemand(context, jobId, action, null);
+    }
+
+    private String normalizeStatusFilter(String statusFilter) {
+        String normalized = statusFilter == null ? "" : statusFilter.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isBlank()) {
+            return "pending";
+        }
+        if (!ALLOWED_STATUS_FILTERS.contains(normalized)) {
+            throw new AdminBusinessException(
+                    ErrorCodes.VALIDATION_ERROR,
+                    "status must be pending, approved, rejected, or all.",
+                    HttpServletResponse.SC_BAD_REQUEST
+            );
+        }
+        return normalized;
     }
 
     private String normalizeAction(String action) {
@@ -89,11 +155,73 @@ public class AdminDemandReviewService {
         return normalized;
     }
 
+    private String normalizeReason(String normalizedAction, String reason) {
+        if (!"reject".equals(normalizedAction)) {
+            return "";
+        }
+        String normalized = reason == null ? "" : reason.trim();
+        if (normalized.length() > MAX_REJECTION_REASON_LENGTH) {
+            throw new AdminBusinessException(
+                    ErrorCodes.VALIDATION_ERROR,
+                    "rejection reason must be 200 characters or fewer.",
+                    HttpServletResponse.SC_BAD_REQUEST
+            );
+        }
+        return normalized;
+    }
+
     private String toApprovalStatus(String normalizedAction) {
         return "approve".equals(normalizedAction) ? "approved" : "rejected";
     }
 
     private boolean isDemandRecord(JobPosting job) {
         return job.getApprovalStatus() != null || job.getPublished() != null || job.getWithdrawn() != null;
+    }
+
+    private boolean matchesStatus(JobPosting job, String statusFilter) {
+        if ("all".equals(statusFilter)) {
+            return true;
+        }
+        return statusFilter.equalsIgnoreCase(job.getApprovalStatus());
+    }
+
+    private AdminDemandItemResponse toDemandItem(JobPosting job, Map<String, String> userNameById) {
+        AdminDemandItemResponse item = new AdminDemandItemResponse();
+        item.setJobId(job.getId());
+        item.setMoId(job.getTeacherId());
+        item.setTeacherName(firstNonBlank(job.getTeacherName(), userNameById.get(job.getTeacherId()), job.getTeacherId()));
+        item.setModuleCode(job.getModuleCode());
+        item.setTitle(job.getTitle());
+        item.setDepartment(job.getDepartment());
+        item.setPlannedCount(job.getPositions());
+        item.setHourMin(job.getHourMin());
+        item.setHourMax(job.getHourMax());
+        if (job.getHours() > 0) {
+            item.setHours(job.getHours());
+        }
+        item.setApprovalStatus(job.getApprovalStatus());
+        item.setStatus(job.getStatus());
+        item.setPublished(job.getPublished());
+        item.setWithdrawn(job.getWithdrawn());
+        item.setRecruitmentClosed(Boolean.TRUE.equals(job.getRecruitmentClosed()));
+        item.setSchedule(job.getSchedule());
+        item.setLocation(job.getLocation());
+        item.setDeadline(job.getDeadline());
+        item.setRequirements(job.getRequirements());
+        item.setCreatedAt(job.getCreatedAt());
+        item.setUpdatedAt(job.getUpdatedAt());
+        item.setReviewedAt(job.getReviewedAt());
+        item.setRejectionReason(job.getRejectionReason());
+        return item;
+    }
+
+    private String firstNonBlank(String first, String second, String fallback) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        if (second != null && !second.isBlank()) {
+            return second;
+        }
+        return fallback == null ? "" : fallback;
     }
 }

--- a/web/src/main/java/com/ta/service/admin/AdminReportService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminReportService.java
@@ -20,39 +20,65 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class AdminReportService {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Set<String> ALLOWED_STATUS_FILTERS = Set.of("all", "draft", "open", "closed", "withdrawn");
     private final AdminDashboardService adminDashboardService = new AdminDashboardService();
     private final AdminApplicationArchiveService adminApplicationArchiveService = new AdminApplicationArchiveService();
 
     public String buildWeeklyRecruitmentReport(ServletContext context, String format) {
+        return buildWeeklyRecruitmentReport(context, format, "all", "all");
+    }
+
+    public String buildWeeklyRecruitmentReport(ServletContext context, String format, String statusFilter, String departmentFilter) {
         String normalizedFormat = normalizeFormat(format);
+        String normalizedStatus = normalizeStatusFilter(statusFilter);
+        String normalizedDepartment = normalizeFilterValue(departmentFilter);
         try {
             List<JobPosting> jobs = JsonUtility.loadJobs(context);
             List<ApplicationRecord> applications = JsonUtility.loadApplications(context);
             Map<String, Integer> hiredCountByJob = countHiredByJob(applications);
+            List<JobPosting> filteredJobs = filterJobs(jobs, normalizedStatus, normalizedDepartment);
 
-            jobs.sort(Comparator.comparing(JobPosting::getModuleCode, Comparator.nullsLast(String::compareToIgnoreCase))
+            filteredJobs.sort(Comparator.comparing(JobPosting::getModuleCode, Comparator.nullsLast(String::compareToIgnoreCase))
                     .thenComparing(JobPosting::getTitle, Comparator.nullsLast(String::compareToIgnoreCase)));
 
             if ("txt".equals(normalizedFormat)) {
-                return toTextReport(jobs, hiredCountByJob);
+                return toTextReport(filteredJobs, hiredCountByJob);
             }
-            return toCsvReport(jobs, hiredCountByJob);
+            return toCsvReport(filteredJobs, hiredCountByJob);
         } catch (IOException e) {
             throw new RuntimeException("Failed to generate weekly recruitment report.", e);
         }
     }
 
     public String resolveFileName(String format) {
-        return "weekly-recruitment-report." + normalizeFormat(format);
+        return resolveFileName(format, "all", "all");
+    }
+
+    public String resolveFileName(String format, String statusFilter, String departmentFilter) {
+        String normalizedFormat = normalizeFormat(format);
+        String status = normalizeStatusFilter(statusFilter);
+        String department = normalizeFilterValue(departmentFilter);
+        List<String> parts = new ArrayList<>();
+        parts.add("weekly-report");
+        if (!"all".equals(status)) {
+            parts.add("status-" + sanitizeFileNamePart(status));
+        }
+        if (!"all".equals(department)) {
+            parts.add("dept-" + sanitizeFileNamePart(department));
+        }
+        parts.add(LocalDate.now().toString().replace("-", ""));
+        return String.join("-", parts) + "." + normalizedFormat;
     }
 
     public String resolveContentType(String format) {
@@ -73,8 +99,23 @@ public class AdminReportService {
     }
 
     public String buildApplicationArchiveReport(ServletContext context, String format) {
+        return buildApplicationArchiveReport(context, format, "all", "all", "all", "all");
+    }
+
+    public String buildApplicationArchiveReport(ServletContext context,
+                                                String format,
+                                                String statusFilter,
+                                                String jobIdFilter,
+                                                String teacherFilter,
+                                                String studentFilter) {
         String normalizedFormat = normalizeFormat(format);
-        AdminApplicationArchiveResponse archive = adminApplicationArchiveService.listArchive(context, "all", "all", "all", "all");
+        AdminApplicationArchiveResponse archive = adminApplicationArchiveService.listArchive(
+                context,
+                statusFilter,
+                jobIdFilter,
+                teacherFilter,
+                studentFilter
+        );
         if ("txt".equals(normalizedFormat)) {
             return applicationsToText(archive.getItems());
         }
@@ -116,9 +157,29 @@ public class AdminReportService {
         );
     }
 
+    private String normalizeStatusFilter(String statusFilter) {
+        String normalized = normalizeFilterValue(statusFilter).toLowerCase(Locale.ROOT);
+        if (!ALLOWED_STATUS_FILTERS.contains(normalized)) {
+            throw new AdminBusinessException(
+                    ErrorCodes.VALIDATION_ERROR,
+                    "status must be all, draft, open, closed, or withdrawn.",
+                    HttpServletResponse.SC_BAD_REQUEST
+            );
+        }
+        return normalized;
+    }
+
+    private String normalizeFilterValue(String value) {
+        String normalized = value == null ? "" : value.trim();
+        return normalized.isBlank() || "all".equalsIgnoreCase(normalized) ? "all" : normalized;
+    }
+
     private Map<String, Integer> countHiredByJob(List<ApplicationRecord> applications) {
         Map<String, Integer> counts = new LinkedHashMap<>();
         for (ApplicationRecord app : applications) {
+            if (!app.isActive()) {
+                continue;
+            }
             if (!"hired".equalsIgnoreCase(app.getStatus())) {
                 continue;
             }
@@ -128,6 +189,48 @@ public class AdminReportService {
             counts.put(app.getJobId(), counts.getOrDefault(app.getJobId(), 0) + 1);
         }
         return counts;
+    }
+
+    private List<JobPosting> filterJobs(List<JobPosting> jobs, String statusFilter, String departmentFilter) {
+        List<JobPosting> filtered = new ArrayList<>();
+        for (JobPosting job : jobs) {
+            if (!matchesStatus(job, statusFilter)) {
+                continue;
+            }
+            if (!matchesDepartment(job, departmentFilter)) {
+                continue;
+            }
+            filtered.add(job);
+        }
+        return filtered;
+    }
+
+    private boolean matchesStatus(JobPosting job, String statusFilter) {
+        if ("all".equals(statusFilter)) {
+            return true;
+        }
+        boolean withdrawn = Boolean.TRUE.equals(job.getWithdrawn());
+        boolean closed = Boolean.TRUE.equals(job.getRecruitmentClosed()) || "closed".equalsIgnoreCase(safe(job.getStatus()).trim());
+        String status = safe(job.getStatus()).trim().toLowerCase(Locale.ROOT);
+        switch (statusFilter) {
+            case "withdrawn":
+                return withdrawn;
+            case "closed":
+                return closed;
+            case "draft":
+                return !withdrawn && !closed && "draft".equals(status);
+            case "open":
+                return !withdrawn && !closed && "open".equals(status);
+            default:
+                return true;
+        }
+    }
+
+    private boolean matchesDepartment(JobPosting job, String departmentFilter) {
+        if ("all".equals(departmentFilter)) {
+            return true;
+        }
+        return safe(job.getDepartment()).trim().equalsIgnoreCase(departmentFilter);
     }
 
     private String toCsvReport(List<JobPosting> jobs, Map<String, Integer> hiredCountByJob) {
@@ -265,5 +368,10 @@ public class AdminReportService {
 
     private String safe(String value) {
         return value == null ? "" : value;
+    }
+
+    private String sanitizeFileNamePart(String value) {
+        String cleaned = safe(value).trim().replaceAll("[^A-Za-z0-9_-]+", "-");
+        return cleaned.isBlank() ? "all" : cleaned;
     }
 }

--- a/web/src/main/java/com/ta/service/admin/AdminReportService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminReportService.java
@@ -1,8 +1,20 @@
 package com.ta.service.admin;
 
 import com.ta.constant.ErrorCodes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ta.dto.admin.AdminApplicationArchiveItemResponse;
+import com.ta.dto.admin.AdminApplicationArchiveResponse;
+import com.ta.dto.admin.AdminDashboardResponse;
+import com.ta.dto.admin.AdminDashboardWorkloadItemResponse;
+import com.ta.dto.admin.AdminDashboardWorkloadJobResponse;
 import com.ta.model.ApplicationRecord;
+import com.ta.model.HiringHistoryRecord;
 import com.ta.model.JobPosting;
+import com.ta.model.NotificationRecord;
+import com.ta.model.StudentProfile;
+import com.ta.model.SystemSettings;
+import com.ta.model.User;
 import com.ta.util.JsonUtility;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,6 +28,9 @@ import java.util.Locale;
 import java.util.Map;
 
 public class AdminReportService {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private final AdminDashboardService adminDashboardService = new AdminDashboardService();
+    private final AdminApplicationArchiveService adminApplicationArchiveService = new AdminApplicationArchiveService();
 
     public String buildWeeklyRecruitmentReport(ServletContext context, String format) {
         String normalizedFormat = normalizeFormat(format);
@@ -46,6 +61,47 @@ public class AdminReportService {
             return "text/plain;charset=UTF-8";
         }
         return "text/csv;charset=UTF-8";
+    }
+
+    public String buildWorkloadReport(ServletContext context, String format) {
+        String normalizedFormat = normalizeFormat(format);
+        AdminDashboardResponse dashboard = adminDashboardService.loadDashboard(context, "all", "all");
+        if ("txt".equals(normalizedFormat)) {
+            return workloadToText(dashboard.getWorkload());
+        }
+        return workloadToCsv(dashboard.getWorkload());
+    }
+
+    public String buildApplicationArchiveReport(ServletContext context, String format) {
+        String normalizedFormat = normalizeFormat(format);
+        AdminApplicationArchiveResponse archive = adminApplicationArchiveService.listArchive(context, "all", "all", "all", "all");
+        if ("txt".equals(normalizedFormat)) {
+            return applicationsToText(archive.getItems());
+        }
+        return applicationsToCsv(archive.getItems());
+    }
+
+    public String buildBackupJson(ServletContext context) {
+        try {
+            Map<String, Object> backup = new LinkedHashMap<>();
+            List<User> users = JsonUtility.loadUsers(context);
+            List<StudentProfile> students = JsonUtility.loadStudents(context);
+            List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            List<ApplicationRecord> applications = JsonUtility.loadApplications(context);
+            List<HiringHistoryRecord> hiringHistory = JsonUtility.loadHiringHistory(context);
+            List<NotificationRecord> notifications = JsonUtility.loadNotifications(context);
+            SystemSettings settings = JsonUtility.loadSystemSettings(context);
+            backup.put("users", users);
+            backup.put("students", students);
+            backup.put("jobs", jobs);
+            backup.put("applications", applications);
+            backup.put("hiringHistory", hiringHistory);
+            backup.put("notifications", notifications);
+            backup.put("systemSettings", settings);
+            return GSON.toJson(backup);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to generate admin backup.", e);
+        }
     }
 
     private String normalizeFormat(String format) {
@@ -114,6 +170,88 @@ public class AdminReportService {
             lines.add("");
         }
         return String.join(System.lineSeparator(), lines);
+    }
+
+    private String workloadToCsv(List<AdminDashboardWorkloadItemResponse> workload) {
+        List<String> lines = new ArrayList<>();
+        lines.add("studentId,studentName,hiredCount,weeklyHours,thresholdHours,workloadLevel,assignedJobs");
+        for (AdminDashboardWorkloadItemResponse item : workload) {
+            lines.add(csvRow(
+                    item.getStudentId(),
+                    item.getStudentName(),
+                    String.valueOf(item.getHiredCount()),
+                    String.valueOf(item.getWeeklyHours()),
+                    String.valueOf(item.getThresholdHours()),
+                    item.getWorkloadLabel(),
+                    assignedJobsText(item.getAssignedJobs())
+            ));
+        }
+        return String.join("\r\n", lines);
+    }
+
+    private String workloadToText(List<AdminDashboardWorkloadItemResponse> workload) {
+        List<String> lines = new ArrayList<>();
+        lines.add("TA Workload Report");
+        lines.add("");
+        for (AdminDashboardWorkloadItemResponse item : workload) {
+            lines.add("Student: " + safe(item.getStudentName()) + " (" + safe(item.getStudentId()) + ")");
+            lines.add("Weekly Hours: " + item.getWeeklyHours());
+            lines.add("Level: " + safe(item.getWorkloadLabel()));
+            lines.add("Assigned Jobs: " + assignedJobsText(item.getAssignedJobs()));
+            lines.add("");
+        }
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    private String applicationsToCsv(List<AdminApplicationArchiveItemResponse> items) {
+        List<String> lines = new ArrayList<>();
+        lines.add("applicationId,jobId,moduleCode,title,organiser,studentId,studentNo,studentName,status,appliedAt,evaluationNotes,decisionFeedback");
+        for (AdminApplicationArchiveItemResponse item : items) {
+            lines.add(csvRow(
+                    item.getApplicationId(),
+                    item.getJobId(),
+                    item.getModuleCode(),
+                    item.getTitle(),
+                    item.getTeacherName(),
+                    item.getStudentId(),
+                    item.getStudentNo(),
+                    item.getStudentName(),
+                    item.getStatus(),
+                    item.getAppliedAt(),
+                    item.getEvaluationNotes(),
+                    item.getDecisionFeedback()
+            ));
+        }
+        return String.join("\r\n", lines);
+    }
+
+    private String applicationsToText(List<AdminApplicationArchiveItemResponse> items) {
+        List<String> lines = new ArrayList<>();
+        lines.add("Application Archive Report");
+        lines.add("");
+        for (AdminApplicationArchiveItemResponse item : items) {
+            lines.add("Application ID: " + safe(item.getApplicationId()));
+            lines.add("Student: " + safe(item.getStudentName()) + " (" + safe(item.getStudentNo()) + ")");
+            lines.add("Job: " + safe(item.getModuleCode()) + " " + safe(item.getTitle()));
+            lines.add("Organiser: " + safe(item.getTeacherName()));
+            lines.add("Status: " + safe(item.getStatus()));
+            lines.add("Applied At: " + safe(item.getAppliedAt()));
+            lines.add("Evaluation Notes: " + safe(item.getEvaluationNotes()));
+            lines.add("Decision Feedback: " + safe(item.getDecisionFeedback()));
+            lines.add("");
+        }
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    private String assignedJobsText(List<AdminDashboardWorkloadJobResponse> jobs) {
+        if (jobs == null || jobs.isEmpty()) {
+            return "";
+        }
+        List<String> parts = new ArrayList<>();
+        for (AdminDashboardWorkloadJobResponse job : jobs) {
+            parts.add(safe(job.getModuleCode()) + " " + safe(job.getTitle()) + " (" + job.getWeeklyHours() + "h/week)");
+        }
+        return String.join("; ", parts);
     }
 
     private String csvRow(String... values) {

--- a/web/src/main/java/com/ta/service/mo/MoDemandService.java
+++ b/web/src/main/java/com/ta/service/mo/MoDemandService.java
@@ -5,6 +5,7 @@ import com.ta.dto.mo.MoDemandCreateRequest;
 import com.ta.dto.mo.MoDemandItemResponse;
 import com.ta.dto.mo.MoDemandListResponse;
 import com.ta.model.JobPosting;
+import com.ta.model.User;
 import com.ta.util.JsonUtility;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,7 +22,7 @@ import java.util.UUID;
  * Ownership: A side (demand and publish chain).
  * Rules:
  * 1) One MO cannot submit same course when pending demand exists.
- * 2) New demand is created as approved so it can be published directly.
+ * 2) New demand is created as pending and must be approved by admin before publishing.
  */
 public class MoDemandService {
 
@@ -49,6 +50,7 @@ public class MoDemandService {
 
         try {
             List<JobPosting> jobs = JsonUtility.loadJobs(context);
+            List<User> users = JsonUtility.loadUsers(context);
 
             for (JobPosting job : jobs) {
                 if (!moId.equals(job.getTeacherId())) {
@@ -67,6 +69,7 @@ public class MoDemandService {
             JobPosting job = new JobPosting();
             job.setId("job_" + UUID.randomUUID().toString().replace("-", ""));
             job.setTeacherId(moId);
+            job.setTeacherName(resolveUserName(users, moId));
             job.setTitle(request.getCourseName());
             job.setModuleCode(request.getCourseName());
             job.setDepartment(request.getDepartment().trim());
@@ -74,13 +77,15 @@ public class MoDemandService {
             job.setHourMin(request.getHourMin());
             job.setHourMax(request.getHourMax());
 
-            job.setApprovalStatus("approved");
+            job.setApprovalStatus("pending");
             job.setPublished(false);
             job.setWithdrawn(false);
             job.setStatus("draft");
             job.setLocation(null);
-            job.setRequirements(null);
+            job.setRequirements(normalizeOptionalText(request.getRequirements()));
             job.setDeadline(null);
+            job.setReviewedAt(null);
+            job.setRejectionReason(null);
             job.setCreatedAt(now);
             job.setUpdatedAt(now);
 
@@ -114,6 +119,15 @@ public class MoDemandService {
                     HttpServletResponse.SC_BAD_REQUEST
             );
         }
+
+        String requirements = request.getRequirements();
+        if (requirements != null && requirements.trim().length() > 500) {
+            throw new MoBusinessException(
+                    ErrorCodes.VALIDATION_ERROR,
+                    "requirements must be 500 characters or fewer.",
+                    HttpServletResponse.SC_BAD_REQUEST
+            );
+        }
     }
 
     private MoDemandItemResponse toDemandItem(JobPosting job) {
@@ -141,7 +155,21 @@ public class MoDemandService {
         item.setCreatedAt(job.getCreatedAt());
         item.setUpdatedAt(job.getUpdatedAt());
         item.setPublishedAt(job.getPublishedAt());
+        item.setReviewedAt(job.getReviewedAt());
+        item.setRejectionReason(job.getRejectionReason());
         return item;
+    }
+
+    private String resolveUserName(List<User> users, String userId) {
+        if (users == null) {
+            return userId;
+        }
+        for (User user : users) {
+            if (userId != null && userId.equals(user.getId())) {
+                return user.getName() == null || user.getName().isBlank() ? userId : user.getName();
+            }
+        }
+        return userId;
     }
 
     private boolean sameCourse(JobPosting job, String courseName) {
@@ -155,5 +183,9 @@ public class MoDemandService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private String normalizeOptionalText(String value) {
+        return value == null ? null : value.trim();
     }
 }

--- a/web/src/main/java/com/ta/service/mo/MoJobService.java
+++ b/web/src/main/java/com/ta/service/mo/MoJobService.java
@@ -21,7 +21,7 @@ import java.util.List;
  *
  * Ownership: A side (publish/withdraw rules).
  * Rules:
- * 1) MO can publish a demand directly without admin approval.
+ * 1) MO can publish only admin-approved demands.
  * 2) Deadline cannot be modified after publish.
  * 3) Published jobs can be taken offline and republished later.
  */
@@ -124,6 +124,9 @@ public class MoJobService {
             job.setPublished(false);
             job.setWithdrawn(false);
             job.setStatus("draft");
+            job.setApprovalStatus("pending");
+            job.setReviewedAt(null);
+            job.setRejectionReason(null);
             job.setUpdatedAt(now);
             JsonUtility.saveJobs(context, jobs);
             return toDemandItem(job);
@@ -217,7 +220,7 @@ public class MoJobService {
             copied.setSchedule(source.getSchedule());
             copied.setLocation(source.getLocation());
             copied.setRequirements(source.getRequirements());
-            copied.setApprovalStatus("approved");
+            copied.setApprovalStatus("pending");
             copied.setPublished(false);
             copied.setWithdrawn(false);
             copied.setStatus("draft");
@@ -225,6 +228,8 @@ public class MoJobService {
             copied.setPublishedAt(null);
             copied.setRecruitmentClosed(false);
             copied.setClosedAt(null);
+            copied.setReviewedAt(null);
+            copied.setRejectionReason(null);
             copied.setCreatedAt(now);
             copied.setUpdatedAt(now);
 
@@ -343,6 +348,8 @@ public class MoJobService {
         item.setCreatedAt(job.getCreatedAt());
         item.setUpdatedAt(job.getUpdatedAt());
         item.setPublishedAt(job.getPublishedAt());
+        item.setReviewedAt(job.getReviewedAt());
+        item.setRejectionReason(job.getRejectionReason());
         return item;
     }
 

--- a/web/src/main/java/com/ta/web/AdminApplicationArchiveExportServlet.java
+++ b/web/src/main/java/com/ta/web/AdminApplicationArchiveExportServlet.java
@@ -22,7 +22,14 @@ public class AdminApplicationArchiveExportServlet extends AdminBaseServlet {
             }
 
             String format = req.getParameter("format");
-            String content = adminReportService.buildApplicationArchiveReport(getServletContext(), format);
+            String content = adminReportService.buildApplicationArchiveReport(
+                    getServletContext(),
+                    format,
+                    req.getParameter("status"),
+                    req.getParameter("jobId"),
+                    req.getParameter("teacher"),
+                    req.getParameter("student")
+            );
             String normalizedFormat = format == null ? "" : format.trim().toLowerCase();
 
             resp.setStatus(HttpServletResponse.SC_OK);

--- a/web/src/main/java/com/ta/web/AdminApplicationArchiveExportServlet.java
+++ b/web/src/main/java/com/ta/web/AdminApplicationArchiveExportServlet.java
@@ -1,0 +1,39 @@
+package com.ta.web;
+
+import com.ta.service.admin.AdminBusinessException;
+import com.ta.service.admin.AdminReportService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@WebServlet(name = "AdminApplicationArchiveExportServlet", urlPatterns = {"/api/admin/reports/applications"})
+public class AdminApplicationArchiveExportServlet extends AdminBaseServlet {
+    private final AdminReportService adminReportService = new AdminReportService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            if (!requireAdmin(req, resp)) {
+                return;
+            }
+
+            String format = req.getParameter("format");
+            String content = adminReportService.buildApplicationArchiveReport(getServletContext(), format);
+            String normalizedFormat = format == null ? "" : format.trim().toLowerCase();
+
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            resp.setContentType(adminReportService.resolveContentType(normalizedFormat));
+            resp.setHeader("Content-Disposition", "attachment; filename=\"application-archive." + normalizedFormat + "\"");
+            resp.getWriter().write(content);
+        } catch (AdminBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/ta/web/AdminApplicationsServlet.java
+++ b/web/src/main/java/com/ta/web/AdminApplicationsServlet.java
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * GET /api/admin/applications?jobId= — read-only list with MO decision fields for archiving (MO_10).
+ * GET /api/admin/applications?jobId= read-only list with MO decision fields for archiving (MO_10).
  */
 @WebServlet(name = "AdminApplicationsServlet", urlPatterns = {"/api/admin/applications"})
 public class AdminApplicationsServlet extends AdminBaseServlet {

--- a/web/src/main/java/com/ta/web/AdminApplicationsServlet.java
+++ b/web/src/main/java/com/ta/web/AdminApplicationsServlet.java
@@ -1,6 +1,6 @@
 package com.ta.web;
 
-import com.ta.service.mo.MoApplicationService;
+import com.ta.service.admin.AdminApplicationArchiveService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,7 +13,7 @@ import java.io.IOException;
  */
 @WebServlet(name = "AdminApplicationsServlet", urlPatterns = {"/api/admin/applications"})
 public class AdminApplicationsServlet extends AdminBaseServlet {
-    private final MoApplicationService moApplicationService = new MoApplicationService();
+    private final AdminApplicationArchiveService adminApplicationArchiveService = new AdminApplicationArchiveService();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -21,8 +21,13 @@ public class AdminApplicationsServlet extends AdminBaseServlet {
             return;
         }
         try {
-            String jobId = req.getParameter("jobId");
-            writeSuccess(resp, moApplicationService.listApplicationsForAdmin(getServletContext(), jobId));
+            writeSuccess(resp, adminApplicationArchiveService.listArchive(
+                    getServletContext(),
+                    req.getParameter("status"),
+                    req.getParameter("jobId"),
+                    req.getParameter("teacher"),
+                    req.getParameter("student")
+            ));
         } catch (Exception ex) {
             writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
         }

--- a/web/src/main/java/com/ta/web/AdminBackupExportServlet.java
+++ b/web/src/main/java/com/ta/web/AdminBackupExportServlet.java
@@ -1,0 +1,33 @@
+package com.ta.web;
+
+import com.ta.service.admin.AdminReportService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@WebServlet(name = "AdminBackupExportServlet", urlPatterns = {"/api/admin/reports/backup"})
+public class AdminBackupExportServlet extends AdminBaseServlet {
+    private final AdminReportService adminReportService = new AdminReportService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            if (!requireAdmin(req, resp)) {
+                return;
+            }
+
+            String content = adminReportService.buildBackupJson(getServletContext());
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            resp.setContentType("application/json;charset=UTF-8");
+            resp.setHeader("Content-Disposition", "attachment; filename=\"admin-data-backup.json\"");
+            resp.getWriter().write(content);
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/ta/web/AdminDemandsServlet.java
+++ b/web/src/main/java/com/ta/web/AdminDemandsServlet.java
@@ -1,0 +1,29 @@
+package com.ta.web;
+
+import com.ta.service.admin.AdminBusinessException;
+import com.ta.service.admin.AdminDemandReviewService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "AdminDemandsServlet", urlPatterns = {"/api/admin/demands"})
+public class AdminDemandsServlet extends AdminBaseServlet {
+    private final AdminDemandReviewService adminDemandReviewService = new AdminDemandReviewService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            if (!requireAdmin(req, resp)) {
+                return;
+            }
+            writeSuccess(resp, adminDemandReviewService.listDemands(getServletContext(), req.getParameter("status")));
+        } catch (AdminBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/ta/web/AdminRecruitmentReportExportServlet.java
+++ b/web/src/main/java/com/ta/web/AdminRecruitmentReportExportServlet.java
@@ -22,8 +22,10 @@ public class AdminRecruitmentReportExportServlet extends AdminBaseServlet {
             }
 
             String format = req.getParameter("format");
-            String content = adminReportService.buildWeeklyRecruitmentReport(getServletContext(), format);
-            String fileName = adminReportService.resolveFileName(format);
+            String status = req.getParameter("status");
+            String department = req.getParameter("department");
+            String content = adminReportService.buildWeeklyRecruitmentReport(getServletContext(), format, status, department);
+            String fileName = adminReportService.resolveFileName(format, status, department);
             String contentType = adminReportService.resolveContentType(format);
 
             resp.setStatus(HttpServletResponse.SC_OK);

--- a/web/src/main/java/com/ta/web/AdminWorkloadReportExportServlet.java
+++ b/web/src/main/java/com/ta/web/AdminWorkloadReportExportServlet.java
@@ -1,0 +1,39 @@
+package com.ta.web;
+
+import com.ta.service.admin.AdminBusinessException;
+import com.ta.service.admin.AdminReportService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@WebServlet(name = "AdminWorkloadReportExportServlet", urlPatterns = {"/api/admin/reports/workload"})
+public class AdminWorkloadReportExportServlet extends AdminBaseServlet {
+    private final AdminReportService adminReportService = new AdminReportService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            if (!requireAdmin(req, resp)) {
+                return;
+            }
+
+            String format = req.getParameter("format");
+            String content = adminReportService.buildWorkloadReport(getServletContext(), format);
+            String normalizedFormat = format == null ? "" : format.trim().toLowerCase();
+
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            resp.setContentType(adminReportService.resolveContentType(normalizedFormat));
+            resp.setHeader("Content-Disposition", "attachment; filename=\"workload-report." + normalizedFormat + "\"");
+            resp.getWriter().write(content);
+        } catch (AdminBusinessException ex) {
+            writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
+        } catch (Exception ex) {
+            writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/ta/web/mo/AdminDemandReviewServlet.java
+++ b/web/src/main/java/com/ta/web/mo/AdminDemandReviewServlet.java
@@ -1,9 +1,11 @@
 package com.ta.web.mo;
 
 import com.ta.constant.ErrorCodes;
+import com.ta.dto.admin.AdminDemandReviewRequest;
 import com.ta.dto.admin.AdminDemandReviewResponse;
 import com.ta.service.admin.AdminBusinessException;
 import com.ta.service.admin.AdminDemandReviewService;
+import com.ta.web.AdminBaseServlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,12 +22,15 @@ import java.io.IOException;
  * POST /api/admin/demands/review/{jobId}?action=approve|reject
  */
 @WebServlet(name = "AdminDemandReviewServlet", urlPatterns = {"/api/admin/demands/review/*"})
-public class AdminDemandReviewServlet extends MoBaseServlet {
+public class AdminDemandReviewServlet extends AdminBaseServlet {
     private final AdminDemandReviewService adminDemandReviewService = new AdminDemandReviewService();
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
+            if (!requireAdmin(req, resp)) {
+                return;
+            }
             String jobId = getLastPathSegment(req);
             String action = req.getParameter("action");
 
@@ -34,12 +39,35 @@ public class AdminDemandReviewServlet extends MoBaseServlet {
                 return;
             }
 
-            AdminDemandReviewResponse data = adminDemandReviewService.reviewDemand(getServletContext(), jobId, action);
+            AdminDemandReviewRequest request = readReviewRequest(req);
+            AdminDemandReviewResponse data = adminDemandReviewService.reviewDemand(
+                    getServletContext(),
+                    jobId,
+                    action,
+                    request == null ? null : request.getReason()
+            );
             writeSuccess(resp, data);
         } catch (AdminBusinessException ex) {
             writeError(resp, ex.getHttpStatus(), ex.getCode(), ex.getMessage());
         } catch (Exception ex) {
             writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage());
         }
+    }
+
+    private AdminDemandReviewRequest readReviewRequest(HttpServletRequest req) throws IOException {
+        if (req.getContentLength() == 0) {
+            return null;
+        }
+        return readJson(req, AdminDemandReviewRequest.class);
+    }
+
+    private String getLastPathSegment(HttpServletRequest req) {
+        String pathInfo = req.getPathInfo();
+        if (pathInfo == null || pathInfo.isBlank() || "/".equals(pathInfo)) {
+            return null;
+        }
+        String normalized = pathInfo.startsWith("/") ? pathInfo.substring(1) : pathInfo;
+        int idx = normalized.lastIndexOf('/');
+        return idx >= 0 ? normalized.substring(idx + 1) : normalized;
     }
 }

--- a/web/src/main/webapp/assets/css/main.css
+++ b/web/src/main/webapp/assets/css/main.css
@@ -964,7 +964,7 @@ th { background: #f8fbff; }
 
 .admin-job-metrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
   gap: 16px;
   margin-bottom: 18px;
 }
@@ -1012,6 +1012,27 @@ th { background: #f8fbff; }
 .metric-filled strong {
   font-size: 22px;
   line-height: 1.2;
+}
+
+.metric-unfilled {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.admin-health-overdue,
+.admin-health-no-applicants,
+.admin-health-closed-unfilled {
+  border-color: #fecaca;
+}
+
+.admin-health-deadline-risk,
+.admin-health-unfilled {
+  border-color: #fde68a;
+}
+
+.admin-health-healthy,
+.admin-health-complete {
+  border-color: #bbf7d0;
 }
 
 .admin-job-footer {
@@ -1280,6 +1301,85 @@ th { background: #f8fbff; }
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+
+.admin-alert-list {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-alert {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  padding: 14px 16px;
+}
+
+.admin-alert strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.admin-alert p {
+  margin: 0 0 6px;
+  color: #475569;
+}
+
+.admin-alert small {
+  color: #64748b;
+}
+
+.admin-alert > span {
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.admin-alert-danger {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.admin-alert-warning {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.admin-alert-info {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.admin-archive-card {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-archive-notes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.admin-archive-notes > div {
+  border-radius: 10px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  padding: 12px;
+}
+
+.admin-archive-notes p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.45;
 }
 
 .legend-dot {

--- a/web/src/main/webapp/assets/css/main.css
+++ b/web/src/main/webapp/assets/css/main.css
@@ -1382,6 +1382,65 @@ th { background: #f8fbff; }
   line-height: 1.45;
 }
 
+.admin-panel-inline-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.admin-demand-card {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-demand-pending {
+  border-color: #fde68a;
+}
+
+.admin-demand-approved {
+  border-color: #bbf7d0;
+}
+
+.admin-demand-rejected {
+  border-color: #fecaca;
+}
+
+.admin-demand-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.admin-demand-detail-grid > div {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 10px 12px;
+}
+
+.admin-demand-requirements,
+.admin-demand-reason {
+  margin: 0;
+  color: #334155;
+  line-height: 1.45;
+}
+
+.admin-demand-reason {
+  border-left: 3px solid #dc2626;
+  padding-left: 10px;
+}
+
+.admin-job-applications-panel {
+  border-color: #bfdbfe;
+}
+
+.admin-app-card {
+  display: grid;
+  gap: 10px;
+}
+
 .legend-dot {
   width: 10px;
   height: 10px;

--- a/web/src/main/webapp/assets/js/admin.js
+++ b/web/src/main/webapp/assets/js/admin.js
@@ -11,6 +11,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   const usersGrouped = byId("adminUsersGrouped");
   const jobsCards = byId("adminJobsCards");
   const workloadCards = byId("adminWorkloadCards");
+  const archiveCards = byId("adminArchiveCards");
+  const archiveBody = byId("adminArchiveBody");
+  const alertsPreview = byId("adminAlertsPreview");
+  const alertsList = byId("adminAlertsList");
   const tabs = Array.from(document.querySelectorAll("[data-admin-tab]"));
   const panels = Array.from(document.querySelectorAll("[data-admin-panel]"));
   const workloadPanel = panels.find((p) => p.getAttribute("data-admin-panel") === "workload") || null;
@@ -31,14 +35,26 @@ document.addEventListener("DOMContentLoaded", async () => {
   const thresholdHoursEl = byId("adminThresholdHours");
   const thresholdUpdatedAtEl = byId("adminThresholdUpdatedAt");
   const thresholdSaveBtn = byId("adminThresholdSaveBtn");
+  const exportWorkloadCsvBtn = byId("adminExportWorkloadCsvBtn");
+  const exportWorkloadTxtBtn = byId("adminExportWorkloadTxtBtn");
 
   const statusFilterEl = byId("adminJobStatusFilter");
   const departmentFilterEl = byId("adminJobDepartmentFilter");
-  const departmentOptionsEl = byId("adminDepartmentOptions");
+  const teacherFilterEl = byId("adminJobTeacherFilter");
   const applyFiltersBtn = byId("adminApplyFiltersBtn");
   const resetFiltersBtn = byId("adminResetFiltersBtn");
   const exportCsvBtn = byId("adminExportCsvBtn");
   const exportTxtBtn = byId("adminExportTxtBtn");
+  const backupBtn = byId("adminBackupBtn");
+
+  const archiveStatusFilterEl = byId("adminArchiveStatusFilter");
+  const archiveJobFilterEl = byId("adminArchiveJobFilter");
+  const archiveTeacherFilterEl = byId("adminArchiveTeacherFilter");
+  const archiveStudentFilterEl = byId("adminArchiveStudentFilter");
+  const archiveApplyBtn = byId("adminArchiveApplyBtn");
+  const archiveResetBtn = byId("adminArchiveResetBtn");
+  const archiveExportCsvBtn = byId("adminArchiveExportCsvBtn");
+  const archiveExportTxtBtn = byId("adminArchiveExportTxtBtn");
 
   const changePasswordForm = byId("adminChangePasswordForm");
   const changePasswordBtn = byId("adminChangePasswordBtn");
@@ -47,12 +63,21 @@ document.addEventListener("DOMContentLoaded", async () => {
   const currentUserName = portal?.getAttribute("data-current-user-name") || "Admin User";
 
   let latestData = null;
+  let latestArchive = null;
   /** When set, workload table re-expands this student after dashboard reload (e.g. save threshold). */
   let openWorkloadStudentId = null;
   let knownDepartments = [];
+  let knownTeachers = [];
   const filters = {
     status: "all",
-    department: "all"
+    department: "all",
+    teacher: "all"
+  };
+  const archiveFilters = {
+    status: "all",
+    jobId: "all",
+    teacher: "all",
+    student: ""
   };
 
   function setNotice(message, isError) {
@@ -76,6 +101,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (tabName === "workload") title.textContent = "TA Workload Statistics";
     if (tabName === "users") title.textContent = "User Management";
     if (tabName === "jobs") title.textContent = "Job Management";
+    if (tabName === "archive") title.textContent = "Application Archive";
+    if (tabName === "alerts") title.textContent = "Administrator Alerts";
     if (tabName === "account") title.textContent = "My Account";
     if (tabName === "overview") title.textContent = `Welcome, ${currentUserName}`;
   }
@@ -110,10 +137,34 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function renderDepartmentOptions() {
-    if (!departmentOptionsEl) return;
-    departmentOptionsEl.innerHTML = knownDepartments
-      .map((value) => `<option value="${escapeHtml(value)}"></option>`)
+    if (!departmentFilterEl) return;
+    departmentFilterEl.innerHTML = `<option value="all">All Departments</option>` + knownDepartments
+      .map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`)
       .join("");
+    departmentFilterEl.value = filters.department;
+  }
+
+  function renderTeacherOptions() {
+    if (!teacherFilterEl) return;
+    teacherFilterEl.innerHTML = `<option value="all">All Teachers</option>` + knownTeachers
+      .map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`)
+      .join("");
+    teacherFilterEl.value = filters.teacher;
+  }
+
+  function renderArchiveOptions(jobs) {
+    if (archiveJobFilterEl) {
+      archiveJobFilterEl.innerHTML = `<option value="all">All Jobs</option>` + (jobs || [])
+        .map((job) => `<option value="${escapeHtml(job.id)}">${escapeHtml(job.moduleCode || job.id)} - ${escapeHtml(job.title || "Untitled")}</option>`)
+        .join("");
+      archiveJobFilterEl.value = archiveFilters.jobId;
+    }
+    if (archiveTeacherFilterEl) {
+      archiveTeacherFilterEl.innerHTML = `<option value="all">All Teachers</option>` + knownTeachers
+        .map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`)
+        .join("");
+      archiveTeacherFilterEl.value = archiveFilters.teacher;
+    }
   }
 
   async function loadAdminDashboard() {
@@ -131,16 +182,47 @@ document.addEventListener("DOMContentLoaded", async () => {
         .map((job) => String(job.department || "").trim())
         .filter(Boolean)))
         .sort((a, b) => a.localeCompare(b));
+      knownTeachers = Array.from(new Set((latestData.jobs || [])
+        .map((job) => String(job.teacherName || "").trim())
+        .filter(Boolean)))
+        .sort((a, b) => a.localeCompare(b));
       renderDepartmentOptions();
+      renderTeacherOptions();
+      renderArchiveOptions(latestData.jobs || []);
     }
 
     byId("statJobs").textContent = latestData.totalJobs ?? 0;
     byId("statUsers").textContent = latestData.totalUsers ?? 0;
     byId("statApps").textContent = latestData.totalApplications ?? 0;
+    byId("statStudents").textContent = latestData.totalStudents ?? 0;
+    byId("statTeachers").textContent = latestData.totalTeachers ?? 0;
+    byId("statOpenApps").textContent = latestData.totalOpenApplications ?? 0;
     renderOverview(latestData);
     renderUsers(latestData.users || []);
-    renderJobs(latestData.jobs || []);
+    renderJobs(filteredJobsForDisplay(latestData.jobs || []));
     renderWorkload(latestData.workload || []);
+    renderAlerts(latestData.alerts || []);
+  }
+
+  function filteredJobsForDisplay(jobs) {
+    if (!filters.teacher || filters.teacher === "all") {
+      return jobs;
+    }
+    return jobs.filter((job) => String(job.teacherName || "").trim() === filters.teacher);
+  }
+
+  async function loadArchive() {
+    const params = new URLSearchParams();
+    params.set("status", archiveFilters.status || "all");
+    params.set("jobId", archiveFilters.jobId || "all");
+    params.set("teacher", archiveFilters.teacher || "all");
+    if (archiveFilters.student) {
+      params.set("student", archiveFilters.student);
+    }
+    latestArchive = await requestJson(`${window.location.origin}${getContextPath()}/api/admin/applications?${params.toString()}`, {
+      method: "GET"
+    });
+    renderArchive((latestArchive && latestArchive.items) || []);
   }
 
   async function loadThresholdSettings() {
@@ -152,13 +234,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function renderOverview(data) {
-    const jobs = data.jobs || [];
-    const openJobs = jobs.filter((job) => !job.recruitmentClosed).length;
-    const closedJobs = jobs.filter((job) => job.recruitmentClosed).length;
-    const totalHired = (data.workload || []).reduce((sum, item) => sum + Number(item.hiredCount || 0), 0);
-    byId("overviewOpenJobs").textContent = openJobs;
-    byId("overviewClosedJobs").textContent = closedJobs;
-    byId("overviewHiredCount").textContent = totalHired;
+    byId("overviewOpenJobs").textContent = data.totalActiveJobs ?? 0;
+    byId("overviewClosedJobs").textContent = data.totalClosedJobs ?? 0;
+    byId("overviewHiredCount").textContent = data.totalHiredRecords ?? 0;
+    byId("overviewUnfilledPositions").textContent = data.totalUnfilledPositions ?? 0;
+    byId("overviewRiskStudents").textContent = Number(data.totalWarningStudents || 0) + Number(data.totalOverloadedStudents || 0);
+    byId("overviewAlerts").textContent = (data.alerts || []).length;
   }
 
   function buildUserActions(user, adminCount) {
@@ -218,7 +299,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function formatHiredAtDisplay(value) {
-    if (!value) return "—";
+    if (!value) return "-";
     const text = String(value);
     const isoDate = text.match(/^(\d{4}-\d{2}-\d{2})/);
     return isoDate ? isoDate[1] : text;
@@ -243,8 +324,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     return jobs.map((job) => `
       <tr>
-        <td>${escapeHtml(job.moduleCode || "—")}</td>
-        <td>${escapeHtml(job.title || job.jobId || "—")}</td>
+        <td>${escapeHtml(job.moduleCode || "-")}</td>
+        <td>${escapeHtml(job.title || job.jobId || "-")}</td>
         <td>${escapeHtml(String(job.weeklyHours ?? 0))}</td>
         <td>${escapeHtml(formatHiredAtDisplay(job.hiredAt))}</td>
       </tr>
@@ -277,14 +358,16 @@ document.addEventListener("DOMContentLoaded", async () => {
       const positions = Number(job.positions || 0);
       const hired = Number(job.hiredCount || 0);
       const applicants = Number(job.applicantCount || 0);
+      const unfilled = Number(job.unfilledCount ?? Math.max(positions - hired, 0));
       const postedDate = formatDate(job.publishedAt || job.createdAt);
       return `
-        <article class="card admin-job-card admin-job-card-large ${status.level}">
+        <article class="card admin-job-card admin-job-card-large ${status.level} admin-health-${escapeHtml(job.healthLevel || "unknown")}">
           <div class="admin-job-heading">
             <div>
               <div class="admin-job-title-line">
                 <h3 class="admin-job-title">${escapeHtml(job.moduleCode || "-")} - ${escapeHtml(job.title || "Untitled Job")}</h3>
                 <span class="tag ${status.cls}">${status.icon}${status.label}</span>
+                <span class="tag ${healthTagClass(job.healthLevel)}">${escapeHtml(job.healthLabel || "Health Unknown")}</span>
               </div>
               <p class="admin-list-meta">Module Organiser: ${escapeHtml(job.teacherName || "-")} &middot; Posted: ${escapeHtml(postedDate || "-")}</p>
             </div>
@@ -305,11 +388,15 @@ document.addEventListener("DOMContentLoaded", async () => {
             </div>
             <div class="admin-job-metric metric-filled">
               <span>Status</span>
-              <strong>${escapeHtml(String(hired))}/${escapeHtml(String(positions))} Filled</strong>
+              <strong>${escapeHtml(job.filledLabel || `${hired}/${positions} Filled`)}</strong>
+            </div>
+            <div class="admin-job-metric metric-unfilled">
+              <span>Unfilled</span>
+              <strong>${escapeHtml(String(unfilled))}</strong>
             </div>
           </div>
           <div class="admin-job-footer">
-            <p class="admin-job-meta">Hours/Week: ${escapeHtml(String(job.weeklyHours || 0))}h &middot; Rate: - &middot; Deadline: ${escapeHtml(job.deadline || "-")}</p>
+            <p class="admin-job-meta">Hours/Week: ${escapeHtml(String(job.weeklyHours || 0))}h &middot; Rate: - &middot; Deadline: ${escapeHtml(job.deadline || "-")}${deadlineSuffix(job)}</p>
             <div class="row" style="gap:8px;">
               <button class="btn btn-outline" type="button" data-job-details="${escapeHtml(job.id)}">View Details</button>
               ${job.recruitmentClosed ? `<button class="btn btn-outline" type="button" data-reopen-job="${escapeHtml(job.id)}">Reopen</button>` : ""}
@@ -333,17 +420,34 @@ document.addEventListener("DOMContentLoaded", async () => {
         <td>${escapeHtml(job.teacherName)}</td>
         <td>${escapeHtml(String(job.applicantCount || 0))}</td>
         <td>${escapeHtml(String(job.hiredCount || 0))}</td>
-        <td>${escapeHtml(normalizeJobStatus(job).label)}</td>
+        <td>${escapeHtml(normalizeJobStatus(job).label)} / ${escapeHtml(job.healthLabel || "-")}</td>
         <td>${job.recruitmentClosed ? `<button class="btn btn-outline" data-reopen-job="${escapeHtml(job.id)}">Reopen</button>` : "-"}</td>
       </tr>
     `).join("");
   }
 
+  function healthTagClass(level) {
+    const value = String(level || "").toLowerCase();
+    if (["overdue", "closed-unfilled", "no-applicants"].includes(value)) return "danger";
+    if (["deadline-risk", "unfilled"].includes(value)) return "warn";
+    if (["healthy", "complete"].includes(value)) return "ok";
+    return "low";
+  }
+
+  function deadlineSuffix(job) {
+    if (job.daysUntilDeadline === null || job.daysUntilDeadline === undefined) return "";
+    const days = Number(job.daysUntilDeadline);
+    if (Number.isNaN(days)) return "";
+    if (days < 0) return ` (${Math.abs(days)} day(s) overdue)`;
+    if (days === 0) return " (today)";
+    return ` (${days} day(s) left)`;
+  }
+
   function workloadTier(item) {
     const level = String(item.workloadLevel || "").toLowerCase();
-    if (level === "overload") return { level: "overload", label: "Overload", cls: "danger", icon: "\u25CF " };
-    if (level === "warning") return { level: "warning", label: "Warning", cls: "warn", icon: "\u25B3 " };
-    if (level === "normal") return { level: "normal", label: "Normal", cls: "ok", icon: "\u2713 " };
+    if (level === "overload") return { level: "overload", label: "Overload", cls: "danger", icon: "!" };
+    if (level === "warning") return { level: "warning", label: "Warning", cls: "warn", icon: "!" };
+    if (level === "normal") return { level: "normal", label: "Normal", cls: "ok", icon: "OK" };
     return { level: "low", label: "Low", cls: "low", icon: "" };
   }
 
@@ -472,7 +576,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const assignedJobs = sortAssignedJobsForDisplay(item.assignedJobs);
       const cardJobLines = assignedJobs.length
         ? `<ul>${assignedJobs.map((job) => `
-          <li>${escapeHtml(job.moduleCode || job.jobId || "Job")}: ${escapeHtml(job.title || "")} — ${escapeHtml(String(job.weeklyHours ?? 0))}h/wk, hired ${escapeHtml(formatHiredAtDisplay(job.hiredAt))}</li>
+          <li>${escapeHtml(job.moduleCode || job.jobId || "Job")}: ${escapeHtml(job.title || "")} - ${escapeHtml(String(job.weeklyHours ?? 0))}h/wk, hired ${escapeHtml(formatHiredAtDisplay(job.hiredAt))}</li>
         `).join("")}</ul>`
         : `<p class="admin-list-meta">No job-level breakdown.</p>`;
       return `
@@ -617,6 +721,74 @@ document.addEventListener("DOMContentLoaded", async () => {
     toggleWorkloadTableAtIndex(idx);
   }
 
+  function renderAlerts(alerts) {
+    const items = Array.isArray(alerts) ? alerts : [];
+    const previewItems = items.slice(0, 4);
+    if (alertsPreview) {
+      alertsPreview.innerHTML = previewItems.map(alertHtml).join("")
+        || `<div class="admin-alert admin-alert-info"><strong>No alerts</strong><p>No active admin alerts.</p></div>`;
+    }
+    if (alertsList) {
+      alertsList.innerHTML = items.map(alertHtml).join("")
+        || `<div class="admin-alert admin-alert-info"><strong>No alerts</strong><p>No workload, vacancy, deadline, or metadata alerts found.</p></div>`;
+    }
+  }
+
+  function alertHtml(alert) {
+    const severity = String(alert.severity || "info").toLowerCase();
+    return `
+      <article class="admin-alert admin-alert-${escapeHtml(severity)}">
+        <div>
+          <strong>${escapeHtml(alert.title || "Alert")}</strong>
+          <p>${escapeHtml(alert.message || "")}</p>
+          <small>${escapeHtml(alert.ownerName || "-")} ${alert.dueDate ? `| Due: ${escapeHtml(alert.dueDate)}` : ""}</small>
+        </div>
+        <span>${escapeHtml((alert.type || "info").toUpperCase())}</span>
+      </article>
+    `;
+  }
+
+  function renderArchive(items) {
+    const rows = Array.isArray(items) ? items : [];
+    if (archiveCards) {
+      archiveCards.innerHTML = rows.map((item) => `
+        <article class="card admin-archive-card">
+          <div class="admin-job-title-line">
+            <h3 class="admin-job-title">${escapeHtml(item.moduleCode || item.jobId || "-")} - ${escapeHtml(item.title || "Unknown Job")}</h3>
+            <span class="tag ${archiveStatusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
+          </div>
+          <p class="admin-list-meta">Student: ${escapeHtml(item.studentName || item.studentId || "-")} - Organiser: ${escapeHtml(item.teacherName || "-")} - Applied: ${escapeHtml(formatDate(item.appliedAt) || "-")}</p>
+          <div class="admin-archive-notes">
+            <div><span class="admin-key">Evaluation Notes</span><p>${escapeHtml(item.evaluationNotes || "-")}</p></div>
+            <div><span class="admin-key">Decision Feedback</span><p>${escapeHtml(item.decisionFeedback || "-")}</p></div>
+          </div>
+        </article>
+      `).join("") || `<div class="card"><p class="admin-empty-text">No archived applications found.</p></div>`;
+    }
+
+    if (archiveBody) {
+      archiveBody.innerHTML = rows.map((item) => `
+        <tr>
+          <td>${escapeHtml(item.applicationId || "-")}</td>
+          <td>${escapeHtml(item.studentName || item.studentId || "-")}</td>
+          <td>${escapeHtml(item.moduleCode || item.jobId || "-")}</td>
+          <td>${escapeHtml(item.teacherName || "-")}</td>
+          <td>${escapeHtml(formatStatus(item.status))}</td>
+          <td>${escapeHtml(formatDate(item.appliedAt) || "-")}</td>
+          <td>${escapeHtml(item.decisionFeedback || item.evaluationNotes || "-")}</td>
+        </tr>
+      `).join("") || `<tr><td colspan="7">No archived applications found.</td></tr>`;
+    }
+  }
+
+  function archiveStatusClass(status) {
+    const value = String(status || "").toLowerCase();
+    if (value === "hired") return "ok";
+    if (value === "rejected") return "danger";
+    if (value === "shortlisted") return "warn";
+    return "low";
+  }
+
   async function createUser(event) {
     event.preventDefault();
     const payload = {
@@ -685,6 +857,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     filters.status = statusFilterEl.value || "all";
     const department = (departmentFilterEl.value || "").trim();
     filters.department = department ? department : "all";
+    filters.teacher = teacherFilterEl.value || "all";
     try {
       await loadAdminDashboard();
       setNotice("Job filters applied.", false);
@@ -698,8 +871,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function resetFilters() {
     filters.status = "all";
     filters.department = "all";
+    filters.teacher = "all";
     statusFilterEl.value = "all";
-    departmentFilterEl.value = "";
+    departmentFilterEl.value = "all";
+    teacherFilterEl.value = "all";
     try {
       await loadAdminDashboard();
       setNotice("Job filters reset.", false);
@@ -713,15 +888,66 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function downloadReport(format) {
     const button = format === "csv" ? exportCsvBtn : exportTxtBtn;
     const defaultText = format === "csv" ? "Export CSV" : "Export TXT";
+    await downloadAdminFile(
+      `/api/admin/reports/weekly?format=${encodeURIComponent(format)}`,
+      `weekly-recruitment-report.${format}`,
+      button,
+      defaultText,
+      `Weekly ${format.toUpperCase()} report exported.`,
+      "jobs"
+    );
+  }
+
+  async function downloadWorkloadReport(format) {
+    const button = format === "csv" ? exportWorkloadCsvBtn : exportWorkloadTxtBtn;
+    const defaultText = format === "csv" ? "Export Workload CSV" : "Export Workload TXT";
+    await downloadAdminFile(
+      `/api/admin/reports/workload?format=${encodeURIComponent(format)}`,
+      `workload-report.${format}`,
+      button,
+      defaultText,
+      `Workload ${format.toUpperCase()} report exported.`,
+      "workload"
+    );
+  }
+
+  async function downloadArchiveReport(format) {
+    const button = format === "csv" ? archiveExportCsvBtn : archiveExportTxtBtn;
+    const defaultText = format === "csv" ? "Export Archive CSV" : "Export Archive TXT";
+    await downloadAdminFile(
+      `/api/admin/reports/applications?format=${encodeURIComponent(format)}`,
+      `application-archive.${format}`,
+      button,
+      defaultText,
+      `Application archive ${format.toUpperCase()} exported.`,
+      "archive"
+    );
+  }
+
+  async function downloadBackup() {
+    await downloadAdminFile(
+      "/api/admin/reports/backup",
+      "admin-data-backup.json",
+      backupBtn,
+      "Backup JSON",
+      "Admin data backup exported.",
+      "jobs",
+      true
+    );
+  }
+
+  async function downloadAdminFile(path, fileName, button, defaultText, successMessage, tabName, allowJson) {
     try {
-      button.disabled = true;
-      button.textContent = "Preparing...";
-      const response = await fetch(`${window.location.origin}${getContextPath()}/api/admin/reports/weekly?format=${encodeURIComponent(format)}`, {
+      if (button) {
+        button.disabled = true;
+        button.textContent = "Preparing...";
+      }
+      const response = await fetch(`${window.location.origin}${getContextPath()}${path}`, {
         method: "GET",
         credentials: "same-origin"
       });
       const contentType = response.headers.get("content-type") || "";
-      if (!response.ok || contentType.includes("application/json")) {
+      if (!response.ok || (!allowJson && contentType.includes("application/json"))) {
         const errorBody = await response.json();
         throw new Error(errorBody.message || "Export failed.");
       }
@@ -729,19 +955,55 @@ document.addEventListener("DOMContentLoaded", async () => {
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `weekly-recruitment-report.${format}`;
+      link.download = fileName;
       document.body.appendChild(link);
       link.click();
       link.remove();
       URL.revokeObjectURL(url);
-      setNotice(`Weekly ${format.toUpperCase()} report exported.`, false);
-      activateTab("jobs");
+      setNotice(successMessage, false);
+      activateTab(tabName);
     } catch (err) {
       setNotice(err.message, true);
-      activateTab("jobs");
+      activateTab(tabName);
     } finally {
-      button.disabled = false;
-      button.textContent = defaultText;
+      if (button) {
+        button.disabled = false;
+        button.textContent = defaultText;
+      }
+    }
+  }
+
+  async function applyArchiveFilters() {
+    archiveFilters.status = archiveStatusFilterEl.value || "all";
+    archiveFilters.jobId = archiveJobFilterEl.value || "all";
+    archiveFilters.teacher = archiveTeacherFilterEl.value || "all";
+    archiveFilters.student = archiveStudentFilterEl.value.trim();
+    try {
+      await loadArchive();
+      setNotice("Archive filters applied.", false);
+      activateTab("archive");
+    } catch (err) {
+      setNotice(err.message, true);
+      activateTab("archive");
+    }
+  }
+
+  async function resetArchiveFilters() {
+    archiveFilters.status = "all";
+    archiveFilters.jobId = "all";
+    archiveFilters.teacher = "all";
+    archiveFilters.student = "";
+    archiveStatusFilterEl.value = "all";
+    archiveJobFilterEl.value = "all";
+    archiveTeacherFilterEl.value = "all";
+    archiveStudentFilterEl.value = "";
+    try {
+      await loadArchive();
+      setNotice("Archive filters reset.", false);
+      activateTab("archive");
+    } catch (err) {
+      setNotice(err.message, true);
+      activateTab("archive");
     }
   }
 
@@ -905,12 +1167,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   resetFiltersBtn.addEventListener("click", resetFilters);
   exportCsvBtn.addEventListener("click", () => downloadReport("csv"));
   exportTxtBtn.addEventListener("click", () => downloadReport("txt"));
+  exportWorkloadCsvBtn.addEventListener("click", () => downloadWorkloadReport("csv"));
+  exportWorkloadTxtBtn.addEventListener("click", () => downloadWorkloadReport("txt"));
+  backupBtn.addEventListener("click", downloadBackup);
+  archiveApplyBtn.addEventListener("click", applyArchiveFilters);
+  archiveResetBtn.addEventListener("click", resetArchiveFilters);
+  archiveExportCsvBtn.addEventListener("click", () => downloadArchiveReport("csv"));
+  archiveExportTxtBtn.addEventListener("click", () => downloadArchiveReport("txt"));
   changePasswordForm.addEventListener("submit", changeOwnPassword);
 
   syncCreateRoleFields();
   activateTab("overview");
   try {
-    await Promise.all([loadAdminDashboard(), loadThresholdSettings()]);
+    await Promise.all([loadAdminDashboard(), loadThresholdSettings(), loadArchive()]);
   } catch (err) {
     setNotice(err.message, true);
   }
@@ -923,4 +1192,14 @@ function escapeHtml(value) {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+function formatRole(role) {
+  const value = String(role || "");
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : "-";
+}
+
+function formatStatus(status) {
+  const value = String(status || "");
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : "-";
 }

--- a/web/src/main/webapp/assets/js/admin.js
+++ b/web/src/main/webapp/assets/js/admin.js
@@ -15,6 +15,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   const archiveBody = byId("adminArchiveBody");
   const alertsPreview = byId("adminAlertsPreview");
   const alertsList = byId("adminAlertsList");
+  const demandStatusFilterEl = byId("adminDemandStatusFilter");
+  const demandRefreshBtn = byId("adminDemandRefreshBtn");
+  const demandCards = byId("adminDemandCards");
+  const demandBody = byId("adminDemandBody");
+  const jobApplicationsPanel = byId("adminJobApplicationsPanel");
+  const jobApplicationsTitle = byId("adminJobApplicationsTitle");
+  const jobApplicationsCloseBtn = byId("adminJobApplicationsCloseBtn");
+  const jobApplicationsStatusFilterEl = byId("adminJobApplicationStatusFilter");
+  const jobApplicationsApplyBtn = byId("adminJobApplicationsApplyBtn");
+  const jobApplicationsCsvBtn = byId("adminJobApplicationsCsvBtn");
+  const jobApplicationsTxtBtn = byId("adminJobApplicationsTxtBtn");
+  const jobApplicationCards = byId("adminJobApplicationCards");
+  const jobApplicationBody = byId("adminJobApplicationBody");
   const tabs = Array.from(document.querySelectorAll("[data-admin-tab]"));
   const panels = Array.from(document.querySelectorAll("[data-admin-panel]"));
   const workloadPanel = panels.find((p) => p.getAttribute("data-admin-panel") === "workload") || null;
@@ -64,8 +77,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   let latestData = null;
   let latestArchive = null;
+  let latestDemands = null;
   /** When set, workload table re-expands this student after dashboard reload (e.g. save threshold). */
   let openWorkloadStudentId = null;
+  let currentJobApplicationJobId = null;
+  let currentJobApplicationTitle = "";
   let knownDepartments = [];
   let knownTeachers = [];
   const filters = {
@@ -78,6 +94,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     jobId: "all",
     teacher: "all",
     student: ""
+  };
+  const demandFilters = {
+    status: "pending"
+  };
+  const jobApplicationFilters = {
+    status: "all"
   };
 
   function setNotice(message, isError) {
@@ -100,6 +122,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (!title) return;
     if (tabName === "workload") title.textContent = "TA Workload Statistics";
     if (tabName === "users") title.textContent = "User Management";
+    if (tabName === "demands") title.textContent = "Demand Approval Workbench";
     if (tabName === "jobs") title.textContent = "Job Management";
     if (tabName === "archive") title.textContent = "Application Archive";
     if (tabName === "alerts") title.textContent = "Administrator Alerts";
@@ -225,6 +248,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderArchive((latestArchive && latestArchive.items) || []);
   }
 
+  async function loadDemands() {
+    const params = new URLSearchParams();
+    params.set("status", demandFilters.status || "pending");
+    latestDemands = await requestJson(`${window.location.origin}${getContextPath()}/api/admin/demands?${params.toString()}`, {
+      method: "GET"
+    });
+    renderDemands((latestDemands && latestDemands.items) || []);
+  }
+
   async function loadThresholdSettings() {
     const settings = await requestJson(`${window.location.origin}${getContextPath()}/api/admin/settings/workload-threshold`, {
       method: "GET"
@@ -296,6 +328,75 @@ document.addEventListener("DOMContentLoaded", async () => {
         <td>${buildUserActions(user, adminCount)}</td>
       </tr>
     `).join("");
+  }
+
+  function renderDemands(items) {
+    const rows = Array.isArray(items) ? items : [];
+    if (demandCards) {
+      demandCards.innerHTML = rows.map((item) => {
+        const status = String(item.approvalStatus || "pending").toLowerCase();
+        return `
+          <article class="card admin-demand-card admin-demand-${escapeHtml(status)}">
+            <div class="admin-job-title-line">
+              <h3 class="admin-job-title">${escapeHtml(item.moduleCode || "-")} - ${escapeHtml(item.title || "Untitled Demand")}</h3>
+              <span class="tag ${demandStatusClass(status)}">${escapeHtml(formatStatus(status))}</span>
+            </div>
+            <p class="admin-list-meta">Submitted by ${escapeHtml(item.teacherName || item.moId || "-")} on ${escapeHtml(formatDate(item.createdAt) || "-")}</p>
+            <div class="admin-demand-detail-grid">
+              <div><span class="admin-key">Department</span><strong>${escapeHtml(item.department || "-")}</strong></div>
+              <div><span class="admin-key">Planned Count</span><strong>${escapeHtml(String(item.plannedCount ?? "-"))}</strong></div>
+              <div><span class="admin-key">Hours</span><strong>${escapeHtml(formatHourRange(item))}</strong></div>
+              <div><span class="admin-key">Reviewed</span><strong>${escapeHtml(formatDate(item.reviewedAt) || "-")}</strong></div>
+            </div>
+            <p class="admin-demand-requirements">${escapeHtml(item.requirements || "No demand notes yet.")}</p>
+            ${item.rejectionReason ? `<p class="admin-demand-reason"><strong>Reject reason:</strong> ${escapeHtml(item.rejectionReason)}</p>` : ""}
+            <div class="row" style="margin-top:12px;">
+              ${demandActionButtons(item)}
+            </div>
+          </article>
+        `;
+      }).join("") || `<div class="card"><p class="admin-empty-text">No demands found for this status.</p></div>`;
+    }
+
+    if (demandBody) {
+      demandBody.innerHTML = rows.map((item) => `
+        <tr>
+          <td>${escapeHtml(item.moduleCode || "-")}</td>
+          <td>${escapeHtml(item.title || "-")}</td>
+          <td>${escapeHtml(item.teacherName || item.moId || "-")}</td>
+          <td>${escapeHtml(formatDate(item.createdAt) || "-")}</td>
+          <td>${escapeHtml(formatStatus(item.approvalStatus))}</td>
+          <td>${demandActionButtons(item)}</td>
+        </tr>
+      `).join("") || `<tr><td colspan="6">No demands found for this status.</td></tr>`;
+    }
+  }
+
+  function demandActionButtons(item) {
+    if (String(item.approvalStatus || "").toLowerCase() !== "pending") {
+      return `<span class="admin-list-meta">Reviewed ${escapeHtml(formatDate(item.reviewedAt) || "-")}</span>`;
+    }
+    return `
+      <button class="btn btn-primary" type="button" data-demand-review="${escapeHtml(item.jobId)}" data-demand-action="approve">Approve</button>
+      <button class="btn btn-outline" type="button" data-demand-review="${escapeHtml(item.jobId)}" data-demand-action="reject">Reject</button>
+    `;
+  }
+
+  function demandStatusClass(status) {
+    const value = String(status || "").toLowerCase();
+    if (value === "approved") return "ok";
+    if (value === "rejected") return "danger";
+    return "warn";
+  }
+
+  function formatHourRange(item) {
+    if (item.hours && Number(item.hours) > 0) {
+      return `${item.hours}h`;
+    }
+    if (item.hourMin !== null && item.hourMin !== undefined && item.hourMax !== null && item.hourMax !== undefined) {
+      return `${item.hourMin}-${item.hourMax}h`;
+    }
+    return "-";
   }
 
   function formatHiredAtDisplay(value) {
@@ -399,6 +500,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             <p class="admin-job-meta">Hours/Week: ${escapeHtml(String(job.weeklyHours || 0))}h &middot; Rate: - &middot; Deadline: ${escapeHtml(job.deadline || "-")}${deadlineSuffix(job)}</p>
             <div class="row" style="gap:8px;">
               <button class="btn btn-outline" type="button" data-job-details="${escapeHtml(job.id)}">View Details</button>
+              <button class="btn btn-outline" type="button" data-job-applications="${escapeHtml(job.id)}" data-job-title="${escapeHtml(job.moduleCode || job.id)} - ${escapeHtml(job.title || "Untitled Job")}">View Applications</button>
               ${job.recruitmentClosed ? `<button class="btn btn-outline" type="button" data-reopen-job="${escapeHtml(job.id)}">Reopen</button>` : ""}
             </div>
           </div>
@@ -421,7 +523,12 @@ document.addEventListener("DOMContentLoaded", async () => {
         <td>${escapeHtml(String(job.applicantCount || 0))}</td>
         <td>${escapeHtml(String(job.hiredCount || 0))}</td>
         <td>${escapeHtml(normalizeJobStatus(job).label)} / ${escapeHtml(job.healthLabel || "-")}</td>
-        <td>${job.recruitmentClosed ? `<button class="btn btn-outline" data-reopen-job="${escapeHtml(job.id)}">Reopen</button>` : "-"}</td>
+        <td>
+          <div class="row" style="gap:8px;">
+            <button class="btn btn-outline" type="button" data-job-applications="${escapeHtml(job.id)}" data-job-title="${escapeHtml(job.moduleCode || job.id)} - ${escapeHtml(job.title || "Untitled Job")}">Applications</button>
+            ${job.recruitmentClosed ? `<button class="btn btn-outline" data-reopen-job="${escapeHtml(job.id)}">Reopen</button>` : ""}
+          </div>
+        </td>
       </tr>
     `).join("");
   }
@@ -789,6 +896,73 @@ document.addEventListener("DOMContentLoaded", async () => {
     return "low";
   }
 
+  async function openJobApplications(jobId, title) {
+    currentJobApplicationJobId = jobId;
+    currentJobApplicationTitle = title || jobId;
+    jobApplicationFilters.status = "all";
+    if (jobApplicationsStatusFilterEl) {
+      jobApplicationsStatusFilterEl.value = "all";
+    }
+    if (jobApplicationsTitle) {
+      jobApplicationsTitle.textContent = `Applications for ${currentJobApplicationTitle}`;
+    }
+    if (jobApplicationsPanel) {
+      jobApplicationsPanel.classList.remove("admin-hidden");
+    }
+    await loadJobApplications();
+    activateTab("jobs");
+    if (jobApplicationsPanel) {
+      jobApplicationsPanel.scrollIntoView({ block: "start", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    }
+  }
+
+  async function loadJobApplications() {
+    if (!currentJobApplicationJobId) {
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set("jobId", currentJobApplicationJobId);
+    params.set("status", jobApplicationFilters.status || "all");
+    const data = await requestJson(`${window.location.origin}${getContextPath()}/api/admin/applications?${params.toString()}`, {
+      method: "GET"
+    });
+    renderJobApplications((data && data.items) || []);
+  }
+
+  function renderJobApplications(items) {
+    const rows = Array.isArray(items) ? items : [];
+    if (jobApplicationCards) {
+      jobApplicationCards.innerHTML = rows.map((item) => `
+        <article class="card admin-app-card">
+          <div class="admin-job-title-line">
+            <h3 class="admin-subtitle">${escapeHtml(item.studentName || item.studentId || "-")}</h3>
+            <span class="tag ${archiveStatusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
+          </div>
+          <p class="admin-list-meta">Student No: ${escapeHtml(item.studentNo || "-")} | Applied: ${escapeHtml(formatDate(item.appliedAt) || "-")}</p>
+          <div class="admin-archive-notes">
+            <div><span class="admin-key">Evaluation Notes</span><p>${escapeHtml(item.evaluationNotes || "-")}</p></div>
+            <div><span class="admin-key">Decision Feedback</span><p>${escapeHtml(item.decisionFeedback || "-")}</p></div>
+          </div>
+        </article>
+      `).join("") || `<div class="card"><p class="admin-empty-text">No applications found for this job and status.</p></div>`;
+    }
+
+    if (jobApplicationBody) {
+      jobApplicationBody.innerHTML = rows.map((item) => `
+        <tr>
+          <td>${escapeHtml(item.studentName || item.studentId || "-")}</td>
+          <td>${escapeHtml(item.studentNo || "-")}</td>
+          <td>${escapeHtml(formatDate(item.appliedAt) || "-")}</td>
+          <td>${escapeHtml(formatStatus(item.status))}</td>
+          <td>
+            <strong>Notes:</strong> ${escapeHtml(item.evaluationNotes || "-")}<br />
+            <strong>Feedback:</strong> ${escapeHtml(item.decisionFeedback || "-")}
+          </td>
+        </tr>
+      `).join("") || `<tr><td colspan="5">No applications found for this job and status.</td></tr>`;
+    }
+  }
+
   async function createUser(event) {
     event.preventDefault();
     const payload = {
@@ -853,6 +1027,60 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
+  async function refreshDemandFilters() {
+    demandFilters.status = demandStatusFilterEl.value || "pending";
+    try {
+      await loadDemands();
+      setNotice("Demand list refreshed.", false);
+      activateTab("demands");
+    } catch (err) {
+      setNotice(err.message, true);
+      activateTab("demands");
+    }
+  }
+
+  async function reviewDemand(button) {
+    const jobId = button.getAttribute("data-demand-review");
+    const action = button.getAttribute("data-demand-action");
+    if (!jobId || !action) {
+      return;
+    }
+    let reason = "";
+    if (action === "reject") {
+      const entered = window.prompt("Enter a short rejection reason (optional):", "");
+      if (entered === null) {
+        return;
+      }
+      reason = entered.trim();
+      if (reason.length > 200) {
+        setNotice("Rejection reason must be 200 characters or fewer.", true);
+        activateTab("demands");
+        return;
+      }
+    } else if (!window.confirm(`Approve demand ${jobId}?`)) {
+      return;
+    }
+
+    try {
+      button.disabled = true;
+      button.textContent = action === "approve" ? "Approving..." : "Rejecting...";
+      await requestJson(`${window.location.origin}${getContextPath()}/api/admin/demands/review/${encodeURIComponent(jobId)}?action=${encodeURIComponent(action)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json;charset=UTF-8" },
+        body: JSON.stringify({ reason })
+      });
+      setNotice(`Demand ${jobId} ${action === "approve" ? "approved" : "rejected"}.`, false);
+      await Promise.all([loadDemands(), loadAdminDashboard()]);
+      activateTab("demands");
+    } catch (err) {
+      setNotice(err.message, true);
+      activateTab("demands");
+    } finally {
+      button.disabled = false;
+      button.textContent = action === "approve" ? "Approve" : "Reject";
+    }
+  }
+
   async function applyFilters() {
     filters.status = statusFilterEl.value || "all";
     const department = (departmentFilterEl.value || "").trim();
@@ -888,9 +1116,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function downloadReport(format) {
     const button = format === "csv" ? exportCsvBtn : exportTxtBtn;
     const defaultText = format === "csv" ? "Export CSV" : "Export TXT";
+    const params = new URLSearchParams();
+    params.set("format", format);
+    params.set("status", filters.status || "all");
+    params.set("department", filters.department || "all");
     await downloadAdminFile(
-      `/api/admin/reports/weekly?format=${encodeURIComponent(format)}`,
-      `weekly-recruitment-report.${format}`,
+      `/api/admin/reports/weekly?${params.toString()}`,
+      weeklyReportFileName(format),
       button,
       defaultText,
       `Weekly ${format.toUpperCase()} report exported.`,
@@ -914,13 +1146,69 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function downloadArchiveReport(format) {
     const button = format === "csv" ? archiveExportCsvBtn : archiveExportTxtBtn;
     const defaultText = format === "csv" ? "Export Archive CSV" : "Export Archive TXT";
+    const params = new URLSearchParams();
+    params.set("format", format);
+    params.set("status", archiveFilters.status || "all");
+    params.set("jobId", archiveFilters.jobId || "all");
+    params.set("teacher", archiveFilters.teacher || "all");
+    if (archiveFilters.student) {
+      params.set("student", archiveFilters.student);
+    }
     await downloadAdminFile(
-      `/api/admin/reports/applications?format=${encodeURIComponent(format)}`,
+      `/api/admin/reports/applications?${params.toString()}`,
       `application-archive.${format}`,
       button,
       defaultText,
       `Application archive ${format.toUpperCase()} exported.`,
       "archive"
+    );
+  }
+
+  async function applyJobApplicationFilter() {
+    jobApplicationFilters.status = jobApplicationsStatusFilterEl.value || "all";
+    try {
+      await loadJobApplications();
+      setNotice("Job application filter applied.", false);
+      activateTab("jobs");
+    } catch (err) {
+      setNotice(err.message, true);
+      activateTab("jobs");
+    }
+  }
+
+  function closeJobApplications() {
+    currentJobApplicationJobId = null;
+    currentJobApplicationTitle = "";
+    if (jobApplicationsPanel) {
+      jobApplicationsPanel.classList.add("admin-hidden");
+    }
+    if (jobApplicationCards) {
+      jobApplicationCards.innerHTML = "";
+    }
+    if (jobApplicationBody) {
+      jobApplicationBody.innerHTML = "";
+    }
+  }
+
+  async function downloadJobApplications(format) {
+    if (!currentJobApplicationJobId) {
+      setNotice("Select a job before exporting applications.", true);
+      activateTab("jobs");
+      return;
+    }
+    const button = format === "csv" ? jobApplicationsCsvBtn : jobApplicationsTxtBtn;
+    const defaultText = format === "csv" ? "Export Job CSV" : "Export Job TXT";
+    const params = new URLSearchParams();
+    params.set("format", format);
+    params.set("jobId", currentJobApplicationJobId);
+    params.set("status", jobApplicationFilters.status || "all");
+    await downloadAdminFile(
+      `/api/admin/reports/applications?${params.toString()}`,
+      `job-applications-${safeFileNamePart(currentJobApplicationJobId)}-${jobApplicationFilters.status || "all"}.${format}`,
+      button,
+      defaultText,
+      `Job application ${format.toUpperCase()} exported.`,
+      "jobs"
     );
   }
 
@@ -971,6 +1259,22 @@ document.addEventListener("DOMContentLoaded", async () => {
         button.textContent = defaultText;
       }
     }
+  }
+
+  function weeklyReportFileName(format) {
+    const parts = ["weekly-report"];
+    if (filters.status && filters.status !== "all") {
+      parts.push(`status-${safeFileNamePart(filters.status)}`);
+    }
+    if (filters.department && filters.department !== "all") {
+      parts.push(`dept-${safeFileNamePart(filters.department)}`);
+    }
+    parts.push(new Date().toISOString().slice(0, 10).replace(/-/g, ""));
+    return `${parts.join("-")}.${format}`;
+  }
+
+  function safeFileNamePart(value) {
+    return String(value || "all").trim().replace(/[^A-Za-z0-9_-]+/g, "-") || "all";
   }
 
   async function applyArchiveFilters() {
@@ -1100,6 +1404,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
+  function handleDemandActions(event) {
+    const reviewButton = event.target.closest("[data-demand-review]");
+    if (!reviewButton) {
+      return;
+    }
+    reviewDemand(reviewButton);
+  }
+
   function onJobDetails(event) {
     const btn = event.target.closest("[data-job-details]");
     if (!btn || !jobsCards.contains(btn)) return;
@@ -1111,8 +1423,23 @@ document.addEventListener("DOMContentLoaded", async () => {
     btn.textContent = expanded ? "Hide Details" : "View Details";
   }
 
+  function onJobApplications(event) {
+    const btn = event.target.closest("[data-job-applications]");
+    if (!btn) return;
+    const jobId = btn.getAttribute("data-job-applications");
+    const title = btn.getAttribute("data-job-title") || jobId;
+    if (!jobId) return;
+    openJobApplications(jobId, title);
+  }
+
   function onJobsCardsClick(event) {
     onJobDetails(event);
+    onJobApplications(event);
+    onReopen(event);
+  }
+
+  function onJobsTableClick(event) {
+    onJobApplications(event);
     onReopen(event);
   }
 
@@ -1150,7 +1477,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.addEventListener("keydown", onWorkloadGlobalKeydown);
   usersBody.addEventListener("click", handleUserActions);
   usersGrouped.addEventListener("click", handleUserActions);
-  jobsBody.addEventListener("click", onReopen);
+  if (demandCards) demandCards.addEventListener("click", handleDemandActions);
+  if (demandBody) demandBody.addEventListener("click", handleDemandActions);
+  jobsBody.addEventListener("click", onJobsTableClick);
   jobsCards.addEventListener("click", onJobsCardsClick);
   workloadBody.addEventListener("click", onWorkloadTableClick);
   workloadCards.addEventListener("click", onWorkloadCardClick);
@@ -1163,6 +1492,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   createRoleEl.addEventListener("change", syncCreateRoleFields);
   createUserForm.addEventListener("submit", createUser);
   thresholdForm.addEventListener("submit", saveThreshold);
+  if (demandRefreshBtn) demandRefreshBtn.addEventListener("click", refreshDemandFilters);
   applyFiltersBtn.addEventListener("click", applyFilters);
   resetFiltersBtn.addEventListener("click", resetFilters);
   exportCsvBtn.addEventListener("click", () => downloadReport("csv"));
@@ -1174,12 +1504,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   archiveResetBtn.addEventListener("click", resetArchiveFilters);
   archiveExportCsvBtn.addEventListener("click", () => downloadArchiveReport("csv"));
   archiveExportTxtBtn.addEventListener("click", () => downloadArchiveReport("txt"));
+  if (jobApplicationsApplyBtn) jobApplicationsApplyBtn.addEventListener("click", applyJobApplicationFilter);
+  if (jobApplicationsCloseBtn) jobApplicationsCloseBtn.addEventListener("click", closeJobApplications);
+  if (jobApplicationsCsvBtn) jobApplicationsCsvBtn.addEventListener("click", () => downloadJobApplications("csv"));
+  if (jobApplicationsTxtBtn) jobApplicationsTxtBtn.addEventListener("click", () => downloadJobApplications("txt"));
   changePasswordForm.addEventListener("submit", changeOwnPassword);
 
   syncCreateRoleFields();
   activateTab("overview");
   try {
-    await Promise.all([loadAdminDashboard(), loadThresholdSettings(), loadArchive()]);
+    await Promise.all([loadAdminDashboard(), loadThresholdSettings(), loadArchive(), loadDemands()]);
   } catch (err) {
     setNotice(err.message, true);
   }

--- a/web/src/main/webapp/assets/js/teacher.js
+++ b/web/src/main/webapp/assets/js/teacher.js
@@ -283,6 +283,7 @@ function renderTeacherJobCard(item) {
       </div>
 
       <p class="notice">Approval status: <strong>${teacherEscapeHtml(teacherSafeText(item.approvalStatus || "pending"))}</strong>. Job status: <strong>${teacherEscapeHtml(teacherSafeText(item.status || "-"))}</strong>. Published: <strong>${teacherEscapeHtml(String(item.published === true))}</strong>. Withdrawn: <strong>${teacherEscapeHtml(String(item.withdrawn === true))}</strong>.</p>
+      ${item.rejectionReason ? `<p class="notice" style="color:#dc2626;">Rejection reason: <strong>${teacherEscapeHtml(item.rejectionReason)}</strong></p>` : ""}
       <p class="notice">Schedule: <strong>${teacherEscapeHtml(teacherSafeText(item.schedule))}</strong>. Location: <strong>${teacherEscapeHtml(teacherSafeText(item.location))}</strong>. Deadline: <strong>${teacherEscapeHtml(teacherSafeText(item.deadline))}</strong>.</p>
 
       <div class="mo-demand-actions">
@@ -311,7 +312,8 @@ async function submitDemandForm(event) {
       department: byId("department").value.trim(),
       plannedCount: Number(byId("plannedCount").value),
       hourMin: Number(byId("hourMin").value),
-      hourMax: Number(byId("hourMax").value)
+      hourMax: Number(byId("hourMax").value),
+      requirements: byId("demandRequirements").value.trim()
     };
 
     const data = await teacherRequest(`${teacherApiBase()}/demands`, {

--- a/web/src/main/webapp/pages/admin.jsp
+++ b/web/src/main/webapp/pages/admin.jsp
@@ -38,6 +38,8 @@
       <button class="admin-tab" data-admin-tab="workload" role="tab" aria-selected="false">Workload</button>
       <button class="admin-tab" data-admin-tab="users" role="tab" aria-selected="false">Users</button>
       <button class="admin-tab" data-admin-tab="jobs" role="tab" aria-selected="false">Jobs</button>
+      <button class="admin-tab" data-admin-tab="archive" role="tab" aria-selected="false">Application Archive</button>
+      <button class="admin-tab" data-admin-tab="alerts" role="tab" aria-selected="false">Alerts</button>
       <button class="admin-tab" data-admin-tab="account" role="tab" aria-selected="false">My Account</button>
     </nav>
 
@@ -61,11 +63,26 @@
           <p id="statApps" class="admin-stat-value">0</p>
           <p class="admin-stat-sub">Current application records</p>
         </article>
+        <article class="admin-stat-card">
+          <p class="admin-stat-label">Students</p>
+          <p id="statStudents" class="admin-stat-value">0</p>
+          <p class="admin-stat-sub">Registered TA applicants</p>
+        </article>
+        <article class="admin-stat-card">
+          <p class="admin-stat-label">Module Organisers</p>
+          <p id="statTeachers" class="admin-stat-value">0</p>
+          <p class="admin-stat-sub">Teacher accounts</p>
+        </article>
+        <article class="admin-stat-card">
+          <p class="admin-stat-label">Open Applications</p>
+          <p id="statOpenApps" class="admin-stat-value">0</p>
+          <p class="admin-stat-sub">Pending, viewed, or shortlisted</p>
+        </article>
       </div>
 
       <div class="card">
         <h3 class="admin-subtitle">Quick Summary</h3>
-        <p class="desc">Use the tabs above to manage workload, users, and jobs.</p>
+        <p class="desc">Use the tabs above to manage workload, users, jobs, archive, and alerts.</p>
         <div class="admin-summary-grid">
           <div class="admin-summary-item">
             <span id="overviewOpenJobs">0</span>
@@ -79,7 +96,24 @@
             <span id="overviewHiredCount">0</span>
             <small>Total Hired Slots</small>
           </div>
+          <div class="admin-summary-item">
+            <span id="overviewUnfilledPositions">0</span>
+            <small>Unfilled Positions</small>
+          </div>
+          <div class="admin-summary-item">
+            <span id="overviewRiskStudents">0</span>
+            <small>Workload Risk Students</small>
+          </div>
+          <div class="admin-summary-item">
+            <span id="overviewAlerts">0</span>
+            <small>Active Alerts</small>
+          </div>
         </div>
+      </div>
+
+      <div class="card" style="margin-top:16px;">
+        <h3 class="admin-subtitle">Priority Alerts</h3>
+        <div id="adminAlertsPreview" class="admin-alert-list"></div>
       </div>
     </section>
 
@@ -105,6 +139,8 @@
           </div>
           <div class="row" style="margin-top:16px;">
             <button id="adminThresholdSaveBtn" type="submit" class="btn btn-primary">Save Threshold</button>
+            <button id="adminExportWorkloadCsvBtn" type="button" class="btn btn-outline">Export Workload CSV</button>
+            <button id="adminExportWorkloadTxtBtn" type="button" class="btn btn-outline">Export Workload TXT</button>
           </div>
         </form>
       </div>
@@ -228,6 +264,7 @@
           <button id="adminResetFiltersBtn" type="button" class="btn btn-outline">Reset</button>
           <button id="adminExportCsvBtn" type="button" class="btn btn-outline">Export CSV</button>
           <button id="adminExportTxtBtn" type="button" class="btn btn-outline">Export TXT</button>
+          <button id="adminBackupBtn" type="button" class="btn btn-outline">Backup JSON</button>
         </div>
       </div>
       <div id="adminJobsCards" class="admin-feed"></div>
@@ -240,6 +277,73 @@
           </table>
         </div>
       </div>
+    </section>
+
+    <section class="admin-panel admin-hidden" data-admin-panel="archive">
+      <div class="admin-headline">
+        <div>
+          <h2 class="admin-section-title">Application Archive</h2>
+          <p class="admin-section-desc">Read-only audit view of applications, MO notes, and decision feedback.</p>
+        </div>
+      </div>
+      <div class="card" style="margin-bottom:16px;">
+        <h3 class="admin-subtitle">Archive Filters and Export</h3>
+        <div class="admin-form-grid">
+          <div class="field">
+            <label for="adminArchiveStatusFilter">Status</label>
+            <select id="adminArchiveStatusFilter">
+              <option value="all">All</option>
+              <option value="pending">Pending</option>
+              <option value="viewed">Viewed</option>
+              <option value="shortlisted">Shortlisted</option>
+              <option value="hired">Hired</option>
+              <option value="rejected">Rejected</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="adminArchiveJobFilter">Job</label>
+            <select id="adminArchiveJobFilter">
+              <option value="all">All Jobs</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="adminArchiveTeacherFilter">Module Organiser</label>
+            <select id="adminArchiveTeacherFilter">
+              <option value="all">All Teachers</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="adminArchiveStudentFilter">Student Search</label>
+            <input id="adminArchiveStudentFilter" type="text" placeholder="Name, user ID, or student no." />
+          </div>
+        </div>
+        <div class="row" style="margin-top:16px;">
+          <button id="adminArchiveApplyBtn" type="button" class="btn btn-primary">Apply Archive Filters</button>
+          <button id="adminArchiveResetBtn" type="button" class="btn btn-outline">Reset</button>
+          <button id="adminArchiveExportCsvBtn" type="button" class="btn btn-outline">Export Archive CSV</button>
+          <button id="adminArchiveExportTxtBtn" type="button" class="btn btn-outline">Export Archive TXT</button>
+        </div>
+      </div>
+      <div id="adminArchiveCards" class="admin-feed"></div>
+      <div class="card">
+        <h3 class="admin-subtitle">Archive Table</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Application</th><th>Student</th><th>Job</th><th>Organiser</th><th>Status</th><th>Applied</th><th>Feedback</th></tr></thead>
+            <tbody id="adminArchiveBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="admin-panel admin-hidden" data-admin-panel="alerts">
+      <div class="admin-headline">
+        <div>
+          <h2 class="admin-section-title">Administrator Alerts</h2>
+          <p class="admin-section-desc">Follow up workload, vacancy, deadline, and data-quality risk cases.</p>
+        </div>
+      </div>
+      <div id="adminAlertsList" class="admin-alert-list"></div>
     </section>
 
     <section class="admin-panel admin-hidden" data-admin-panel="account">

--- a/web/src/main/webapp/pages/admin.jsp
+++ b/web/src/main/webapp/pages/admin.jsp
@@ -37,6 +37,7 @@
       <button class="admin-tab active" data-admin-tab="overview" role="tab" aria-selected="true">System Overview</button>
       <button class="admin-tab" data-admin-tab="workload" role="tab" aria-selected="false">Workload</button>
       <button class="admin-tab" data-admin-tab="users" role="tab" aria-selected="false">Users</button>
+      <button class="admin-tab" data-admin-tab="demands" role="tab" aria-selected="false">Demand Review</button>
       <button class="admin-tab" data-admin-tab="jobs" role="tab" aria-selected="false">Jobs</button>
       <button class="admin-tab" data-admin-tab="archive" role="tab" aria-selected="false">Application Archive</button>
       <button class="admin-tab" data-admin-tab="alerts" role="tab" aria-selected="false">Alerts</button>
@@ -226,6 +227,42 @@
       </div>
     </section>
 
+    <section class="admin-panel admin-hidden" data-admin-panel="demands">
+      <div class="admin-headline">
+        <div>
+          <h2 class="admin-section-title">Demand Approval Workbench</h2>
+          <p class="admin-section-desc">Review Module Organiser demand submissions before they can be published as TA jobs.</p>
+        </div>
+      </div>
+      <div class="card" style="margin-bottom:16px;">
+        <h3 class="admin-subtitle">Demand Filters</h3>
+        <div class="admin-form-grid">
+          <div class="field">
+            <label for="adminDemandStatusFilter">Approval Status</label>
+            <select id="adminDemandStatusFilter">
+              <option value="pending">Pending</option>
+              <option value="approved">Approved</option>
+              <option value="rejected">Rejected</option>
+              <option value="all">All</option>
+            </select>
+          </div>
+        </div>
+        <div class="row" style="margin-top:16px;">
+          <button id="adminDemandRefreshBtn" type="button" class="btn btn-primary">Refresh Demands</button>
+        </div>
+      </div>
+      <div id="adminDemandCards" class="admin-feed"></div>
+      <div class="card">
+        <h3 class="admin-subtitle">Demand Review Table</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Module</th><th>Title</th><th>Organiser</th><th>Submitted</th><th>Status</th><th>Action</th></tr></thead>
+            <tbody id="adminDemandBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
     <section class="admin-panel admin-hidden" data-admin-panel="jobs">
       <div class="admin-headline">
         <div>
@@ -265,6 +302,40 @@
           <button id="adminExportCsvBtn" type="button" class="btn btn-outline">Export CSV</button>
           <button id="adminExportTxtBtn" type="button" class="btn btn-outline">Export TXT</button>
           <button id="adminBackupBtn" type="button" class="btn btn-outline">Backup JSON</button>
+        </div>
+      </div>
+      <div id="adminJobApplicationsPanel" class="card admin-job-applications-panel admin-hidden" style="margin-bottom:16px;">
+        <div class="admin-panel-inline-head">
+          <div>
+            <h3 id="adminJobApplicationsTitle" class="admin-subtitle">Job Applications</h3>
+            <p class="admin-list-meta">Read-only applicant drilldown for the selected job.</p>
+          </div>
+          <button id="adminJobApplicationsCloseBtn" type="button" class="btn btn-outline">Close</button>
+        </div>
+        <div class="admin-form-grid">
+          <div class="field">
+            <label for="adminJobApplicationStatusFilter">Application Status</label>
+            <select id="adminJobApplicationStatusFilter">
+              <option value="all">All</option>
+              <option value="pending">Pending</option>
+              <option value="viewed">Viewed</option>
+              <option value="shortlisted">Shortlisted</option>
+              <option value="hired">Hired</option>
+              <option value="rejected">Rejected</option>
+            </select>
+          </div>
+        </div>
+        <div class="row" style="margin-top:16px;">
+          <button id="adminJobApplicationsApplyBtn" type="button" class="btn btn-primary">Apply Status Filter</button>
+          <button id="adminJobApplicationsCsvBtn" type="button" class="btn btn-outline">Export Job CSV</button>
+          <button id="adminJobApplicationsTxtBtn" type="button" class="btn btn-outline">Export Job TXT</button>
+        </div>
+        <div id="adminJobApplicationCards" class="admin-feed" style="margin-top:16px;"></div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Applicant</th><th>Student No.</th><th>Applied</th><th>Status</th><th>Notes / Feedback</th></tr></thead>
+            <tbody id="adminJobApplicationBody"></tbody>
+          </table>
         </div>
       </div>
       <div id="adminJobsCards" class="admin-feed"></div>

--- a/web/src/main/webapp/pages/teacher.jsp
+++ b/web/src/main/webapp/pages/teacher.jsp
@@ -374,6 +374,10 @@
             <input id="hourMax" type="number" min="1" placeholder="e.g. 12" required />
           </div>
         </div>
+        <div class="field">
+          <label for="demandRequirements">Demand Notes</label>
+          <textarea id="demandRequirements" maxlength="500" placeholder="Brief workload or skill notes for admin review"></textarea>
+        </div>
         <div class="row" style="margin-top:12px;">
           <button class="btn btn-primary" type="submit">Submit Demand</button>
           <button class="btn btn-outline" type="reset">Clear</button>


### PR DESCRIPTION
## Summary
- Add Admin Demand Review workbench for pending/approved/rejected MO demands.
- Add read-only job application drilldown from Admin Jobs, including status filter and per-job exports.
- Make weekly recruitment CSV/TXT exports respect the current job status and department filters.
- Update Sprint 4 functional details for ADM_14, ADM_15, and ADM_16.

## Key Changes
- New `GET /api/admin/demands?status=` endpoint and admin-only demand review workflow.
- Extend demand review reject flow with optional short reason persisted on the demand and shown to the MO.
- MO demand creation now starts as `pending`; approved demands can still publish through the existing MO lifecycle.
- Extend application archive export to support filtered job/status exports.
- Extend weekly report generation to apply dashboard-aligned filters and scoped filenames.

## Verification
- `mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" -DskipTests compile`
- `node --check web/src/main/webapp/assets/js/admin.js`
- `node --check web/src/main/webapp/assets/js/teacher.js`
- `git diff --check`
