### PR TITLE
feat(admin): refine demand review and admin oversight UI

### DIFF
--- a/Function_Details.md
+++ b/Function_Details.md
@@ -554,10 +554,10 @@ The feature provides a dedicated view of accepted jobs, associated schedule info
 - **ADM_08:** As an Admin, I want to view enhanced overview statistics, so that I can quickly understand current user, job, application, vacancy, and recruitment progress across the system.
 - **ADM_09:** As an Admin, I want to monitor recruitment health by job, so that I can identify posts with too few applicants, unfilled vacancies, or approaching deadlines.
 - **ADM_10:** As an Admin, I want workload risk to be displayed with clear levels such as Low, Normal, Warning, and Overload, so that I can distinguish normal workload from potential over-assignment instead of relying on one generic threshold only.
-- **ADM_11:** As an Admin, I want to view and filter an application archive, so that I can audit recruitment decisions and preserve hiring records after recruitment is complete.
+- **ADM_11:** As an Admin, I want to inspect applications from a specific job, so that I can audit applicant status and MO notes without exposing a separate global archive screen.
 - **ADM_12:** As an Admin, I want to export and back up recruitment data in simple file formats, so that the school can keep offline records and share summaries with management.
-- **ADM_13:** As an Admin, I want to receive system alerts for risky or incomplete recruitment situations, so that I can follow up with Module Organisers before issues affect TA allocation.
-- **ADM_14:** As an Admin, I want a demand approval workbench, so that newly submitted Module Organiser TA demands are visible and can be approved or rejected from one place.
+- **ADM_13:** As an Admin, I want to receive system alerts from a header alert modal, so that risks are visible on demand without occupying the main dashboard area.
+- **ADM_14:** As an Admin, I want a demand approval workbench with editable pending / approved / rejected decisions, so that demand review can be corrected or reset from one place.
 - **ADM_15:** As an Admin, I want to drill down from a job to its applications, so that I can audit applicant status and MO notes for a specific post without leaving the administrator portal.
 - **ADM_16:** As an Admin, I want recruitment exports to respect the current job filters, so that exported reports match what is shown on screen.
 
@@ -591,38 +591,48 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
    - Workload cards and legend use the same classification rules so that the UI and backend remain consistent.
    - Assigned job chips show the module/job title and weekly hours used in the calculation.
 
-4. **Application archive**
-   - The admin can view application records including applicant identity, job, organiser, status, timestamps, evaluation notes, and decision feedback where available.
-   - The archive can be filtered by status, job, organiser, or student where the UI supports the filter.
-   - Archive access is read-only; administrators must not edit MO evaluation notes or decision feedback from the archive.
+4. **Single-job application audit**
+   - The standalone application archive page is not exposed in the administrator navigation.
+   - The admin can still open applications from an individual job row or card.
+   - The selected job drilldown shows applicant identity, student number, status, applied time, evaluation notes, and decision feedback where available.
+   - The drilldown is read-only; administrators must not edit MO evaluation notes or decision feedback.
    - Withdrawn, rejected, hired, shortlisted, and pending records remain distinguishable.
 
 5. **Data export and backup**
    - The admin can export weekly recruitment reports in CSV and TXT formats.
    - Exported reports include at least job title, organiser, status, hired count, available positions, and unfilled positions.
    - Export actions do not modify live recruitment data.
-   - The system can be extended to export workload reports, application archives, and JSON backups using the same admin-only access model.
+   - The system can be extended to export workload reports, job-level application drilldowns, and JSON backups using the same admin-only access model.
 
 6. **Administrator alerts**
    - The admin dashboard can surface alerts for overload risk, unfilled jobs, jobs close to deadline, jobs with no applicants, and unusual incomplete records.
    - Alerts include enough context for follow-up, such as job title, organiser, student name, current workload, or deadline.
-   - Alerts can be shown as dashboard cards or a dedicated alert panel.
+   - Alerts are opened from a warning button next to Logout, with a badge showing the active alert count.
+   - The alert modal supports close button, backdrop click, and Escape key dismissal.
    - If no alerts exist, the page shows a clear "No alerts" state.
 
 7. **Demand approval workbench**
    - The admin can view demand records by approval status, especially newly submitted `pending` demands.
    - Demand rows show module code, title, submitting organiser, submitted time, planned count, hour range, demand notes where provided, and current approval status.
-   - The admin can approve a pending demand, after which the MO can publish it through the existing publish workflow.
-   - The admin can reject a pending demand and optionally provide a short rejection reason.
+   - The admin can set each demand to `pending`, `approved`, or `rejected` from the workbench.
+   - Setting a demand to `approved` allows the MO to publish it through the existing publish workflow.
+   - Setting a demand to `pending` or `rejected` prevents MO publishing until it is approved again.
+   - The admin can optionally provide a short rejection reason when selecting `rejected`.
    - Rejected demand reasons are persisted and visible to the submitting MO in the demand progress view.
 
-8. **Single-job application drilldown**
+8. **Recruitment results overview entry**
+   - Recruitment Results is not shown as a top-level tab.
+   - The System Overview panel provides a clear button to open the Recruitment Results view.
+   - Recruitment Results retains KPI cards and adds visual charts, including department hired/vacancy bars and an overall hiring mix chart.
+   - Empty recruitment result datasets show a clear empty chart state instead of broken graphics.
+
+9. **Single-job application drilldown**
    - Each admin job row or card provides a read-only "View Applications" action.
    - The drilldown shows only applications for the selected job, including applicant name, student number, applied time, status, evaluation notes, and decision feedback.
-   - The drilldown can be filtered by application status without changing the global application archive.
+   - The drilldown can be filtered by application status without exposing a separate global application page.
    - The admin can export the selected job's application rows in CSV or TXT format.
 
-9. **Filtered weekly export**
+10. **Filtered weekly export**
    - Weekly recruitment report exports include the same `status` and `department` filters used by the jobs dashboard.
    - Exporting with no filters or `all` filters still produces the full report.
    - Export file names include the selected filter scope and export date where possible.
@@ -634,19 +644,20 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - `AdminDashboardServlet` (`GET /api/admin/dashboard`) remains the main dashboard endpoint and may be extended with additional overview, recruitment health, workload, and alert fields.
   - `AdminWorkloadSettingsServlet` (`GET/POST /api/admin/settings/workload-threshold`) remains responsible for loading and saving the overload threshold.
   - `AdminRecruitmentReportExportServlet` (`GET /api/admin/reports/weekly?format=csv|txt`) remains responsible for downloadable weekly recruitment summaries.
-  - `AdminApplicationsServlet` (`GET /api/admin/applications`) provides read-only application archive rows for administrator audit.
+  - `AdminApplicationsServlet` (`GET /api/admin/applications?jobId=&status=`) provides read-only application rows for the selected job drilldown.
   - `AdminDemandsServlet` (`GET /api/admin/demands?status=pending|approved|rejected|all`) provides the administrator demand approval workbench data.
-  - `AdminDemandReviewServlet` (`POST /api/admin/demands/review/{jobId}?action=approve|reject`) approves or rejects pending demand records; reject accepts an optional JSON body containing `reason`.
+  - `AdminDemandReviewServlet` (`POST /api/admin/demands/review/{jobId}?action=pending|approve|reject`) sets demand approval status; reject accepts an optional JSON body containing `reason`.
   - `AdminWorkloadReportExportServlet` (`GET /api/admin/reports/workload?format=csv|txt`) exports workload rows and assigned job details.
-  - `AdminApplicationArchiveExportServlet` (`GET /api/admin/reports/applications?format=csv|txt&jobId=&status=`) exports the read-only application archive or a single job's filtered application rows.
+  - `AdminApplicationArchiveExportServlet` (`GET /api/admin/reports/applications?format=csv|txt&jobId=&status=`) remains available for exporting a single job's filtered application rows.
   - `AdminBackupExportServlet` (`GET /api/admin/reports/backup`) exports a JSON backup bundle for the current file-based data.
-  - Administrator alerts are returned through `GET /api/admin/dashboard` so the overview and alert panel share one data source.
+  - `AdminRecruitmentOutcomeServlet` (`GET /api/admin/recruitment-outcome`) provides the Recruitment Results view launched from System Overview.
+  - Administrator alerts are returned through `GET /api/admin/dashboard` so the header alert modal shares the dashboard data source.
 
 - **Service Layer:**
   - `AdminDashboardService` computes overview statistics, job health fields, workload rows, and risk labels from `jobs.json`, `applications.json`, `users.json`, and `students.json`.
   - `AdminDemandReviewService` lists demand records and applies approval or rejection decisions while preserving MO-owned job publishing rules.
   - `AdminReportService` prepares CSV and TXT export content using the same job and application aggregation rules as the dashboard, including current job filters for weekly reports.
-  - Application archive logic reads existing `ApplicationRecord` fields without changing MO-owned decision data.
+  - Single-job application drilldown logic reads existing `ApplicationRecord` fields without changing MO-owned decision data.
   - Workload calculation must reuse the shared weekly-hours rule:
     - if `job.hours > 0`, use `hours`;
     - otherwise, if both `hourMin` and `hourMax` exist, use `round((min + max) / 2)`;
@@ -660,24 +671,27 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - Sprint 4 admin features must remain compatible with old JSON records that do not contain newer optional fields such as `department`, `schedule`, or decision feedback.
 
 - **Frontend Integration:**
-  - `admin.jsp` provides separate dashboard areas for overview, workload, users, jobs, demand review, archive, and alerts where implemented.
+  - `admin.jsp` provides separate dashboard areas for overview, workload, users, jobs, demand review, announcements, account settings, and a Recruitment Results view opened from System Overview.
   - `admin.js` loads dashboard data, applies status/department/organiser filters, renders workload level cards, handles demand approval actions, opens single-job application drilldowns, and triggers CSV/TXT export downloads.
+  - Admin alerts are opened through the header warning button instead of a persistent overview card or top-level tab.
+  - The standalone Application Archive tab is removed; job-level application drilldown remains available from Jobs.
   - Workload UI must show level labels, weekly hours, assigned positions, and a legend matching backend classification.
   - Job cards should display business-friendly recruitment health information instead of only raw table columns.
-  - Empty states must be explicit for no jobs, no workload records, no archived applications, and no alerts.
+  - Empty states must be explicit for no jobs, no workload records, no job applications, no recruitment result data, and no alerts.
 
 - **Validation / Business Rules:**
   - All admin APIs require an authenticated admin session.
-  - Admin monitoring views must not expose student-only private upload files unless the existing application archive explicitly requires a downloadable attachment link.
-  - Archive and report APIs are read-only and must not change job status, application status, or MO feedback.
+  - Admin monitoring views must not expose student-only private upload files unless the job-level application drilldown explicitly requires a downloadable attachment link.
+  - Application drilldown and report APIs are read-only and must not change job status, application status, or MO feedback.
   - Filters must be optional; when no filter is supplied, the dashboard returns the full admin-visible dataset.
   - Invalid export formats must return a clear validation error instead of generating an ambiguous file.
-  - Only `pending` demand records can be approved or rejected.
+  - Demand records can be switched between `pending`, `approved`, and `rejected` by admins.
+  - Only `approved` demand records can be published by MOs.
   - Rejection reason text is optional but must remain short enough for display in the MO demand progress view.
 
 - **Session / Access Control:**
   - Non-admin users must be rejected from `/api/admin/*`.
-  - Student and teacher sessions must not be able to access admin reports, archive, workload settings, or alert data.
+  - Student and teacher sessions must not be able to access admin reports, job application drilldown, workload settings, or alert data.
   - Admin actions that modify settings, such as threshold saving, must use POST and must validate the submitted value before persistence.
 
 **Assignee:** Sihan Chen / Tianxiao Ma  

--- a/web/src/main/java/com/ta/service/admin/AdminDemandReviewService.java
+++ b/web/src/main/java/com/ta/service/admin/AdminDemandReviewService.java
@@ -80,14 +80,6 @@ public class AdminDemandReviewService {
                 );
             }
 
-            if (!"pending".equalsIgnoreCase(job.getApprovalStatus())) {
-                throw new AdminBusinessException(
-                        ErrorCodes.VALIDATION_ERROR,
-                        "Only pending demands can be reviewed.",
-                        HttpServletResponse.SC_BAD_REQUEST
-                );
-            }
-
             String now = Instant.now().toString();
             job.setApprovalStatus(targetStatus);
             job.setReviewedAt(now);
@@ -145,10 +137,15 @@ public class AdminDemandReviewService {
         }
 
         String normalized = action.trim().toLowerCase();
-        if (!"approve".equals(normalized) && !"reject".equals(normalized)) {
+        if ("approved".equals(normalized)) {
+            normalized = "approve";
+        } else if ("rejected".equals(normalized)) {
+            normalized = "reject";
+        }
+        if (!"approve".equals(normalized) && !"reject".equals(normalized) && !"pending".equals(normalized)) {
             throw new AdminBusinessException(
                     ErrorCodes.VALIDATION_ERROR,
-                    "action must be approve or reject.",
+                    "action must be pending, approve, or reject.",
                     HttpServletResponse.SC_BAD_REQUEST
             );
         }
@@ -171,7 +168,13 @@ public class AdminDemandReviewService {
     }
 
     private String toApprovalStatus(String normalizedAction) {
-        return "approve".equals(normalizedAction) ? "approved" : "rejected";
+        if ("approve".equals(normalizedAction)) {
+            return "approved";
+        }
+        if ("reject".equals(normalizedAction)) {
+            return "rejected";
+        }
+        return "pending";
     }
 
     private boolean isDemandRecord(JobPosting job) {

--- a/web/src/main/java/com/ta/web/mo/AdminDemandReviewServlet.java
+++ b/web/src/main/java/com/ta/web/mo/AdminDemandReviewServlet.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * POST /api/admin/demands/{jobId}/reject
  *
  * Temporary mapping in this scaffold:
- * POST /api/admin/demands/review/{jobId}?action=approve|reject
+ * POST /api/admin/demands/review/{jobId}?action=pending|approve|reject
  */
 @WebServlet(name = "AdminDemandReviewServlet", urlPatterns = {"/api/admin/demands/review/*"})
 public class AdminDemandReviewServlet extends AdminBaseServlet {

--- a/web/src/main/webapp/assets/css/main.css
+++ b/web/src/main/webapp/assets/css/main.css
@@ -735,6 +735,54 @@ th { background: #f8fbff; }
   color: #64748b;
 }
 
+.admin-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-alert-trigger {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  color: #64748b;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.admin-alert-trigger.has-alerts {
+  color: #b91c1c;
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.admin-alert-trigger strong {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+  border: 2px solid #fff;
+}
+
+.admin-alert-trigger strong.is-empty {
+  background: #94a3b8;
+}
+
 .admin-btn-logout {
   display: inline-flex;
   align-items: center;
@@ -797,11 +845,6 @@ th { background: #f8fbff; }
   color: #2563eb;
   border-bottom-color: #2563eb;
   font-weight: 600;
-}
-
-.admin-tab.admin-tab--outcome.active {
-  color: #0f766e;
-  border-bottom-color: #14b8a6;
 }
 
 .admin-panel {
@@ -907,6 +950,74 @@ th { background: #f8fbff; }
 .admin-outcome-card {
   border-radius: 16px !important;
 }
+
+.admin-outcome-mix-chart {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.admin-donut {
+  --hired-deg: 0deg;
+  --vacancy-deg: 0deg;
+  width: 180px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: conic-gradient(#16a34a 0 var(--hired-deg), #f97316 var(--hired-deg) calc(var(--hired-deg) + var(--vacancy-deg)), #dbeafe calc(var(--hired-deg) + var(--vacancy-deg)) 360deg);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.admin-donut-hole {
+  width: 108px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.admin-donut-hole strong {
+  font-size: 2rem;
+  line-height: 1;
+  color: #0f172a;
+}
+
+.admin-donut-hole span {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.admin-donut-legend {
+  display: grid;
+  gap: 10px;
+  color: #334155;
+}
+
+.admin-donut-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.admin-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.admin-dot-hired { background: #16a34a; }
+.admin-dot-vacancy { background: #f97316; }
+.admin-dot-capacity { background: #dbeafe; border: 1px solid #93c5fd; }
 
 .admin-outcome-kpi-grid {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -1625,25 +1736,71 @@ th { background: #f8fbff; }
   background: #eff6ff;
 }
 
-.admin-archive-card {
-  display: grid;
-  gap: 12px;
+.admin-modal-open {
+  overflow: hidden;
 }
 
-.admin-archive-notes {
+.admin-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.admin-modal.admin-hidden {
+  display: none;
+}
+
+.admin-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.42);
+  backdrop-filter: blur(2px);
+}
+
+.admin-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  max-height: min(760px, 88vh);
+  overflow: auto;
+  border-radius: 18px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.28);
+  padding: 22px;
+}
+
+.admin-modal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.admin-alert-modal-card .admin-alert-list {
+  max-height: 62vh;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.admin-application-notes {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
 }
 
-.admin-archive-notes > div {
+.admin-application-notes > div {
   border-radius: 10px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   padding: 12px;
 }
 
-.admin-archive-notes p {
+.admin-application-notes p {
   margin: 0;
   color: #334155;
   line-height: 1.45;
@@ -1699,6 +1856,34 @@ th { background: #f8fbff; }
   padding-left: 10px;
 }
 
+.admin-demand-review-control {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) minmax(180px, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.admin-demand-review-control--compact {
+  grid-template-columns: minmax(115px, 140px) minmax(160px, 1fr) auto;
+  min-width: 360px;
+}
+
+.admin-demand-review-control select,
+.admin-demand-review-control input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 9px 10px;
+  font: inherit;
+  background: #fff;
+}
+
+.admin-demand-review-control input:disabled {
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
 .admin-job-applications-panel {
   border-color: #bfdbfe;
 }
@@ -1734,5 +1919,12 @@ th { background: #f8fbff; }
 @media (max-width: 560px) {
   .admin-job-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .admin-demand-review-control,
+  .admin-demand-review-control--compact,
+  .admin-modal-head {
+    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 }

--- a/web/src/main/webapp/assets/js/admin.js
+++ b/web/src/main/webapp/assets/js/admin.js
@@ -11,10 +11,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   const usersGrouped = byId("adminUsersGrouped");
   const jobsCards = byId("adminJobsCards");
   const workloadCards = byId("adminWorkloadCards");
-  const archiveCards = byId("adminArchiveCards");
-  const archiveBody = byId("adminArchiveBody");
-  const alertsPreview = byId("adminAlertsPreview");
+  const alertsButton = byId("adminAlertsButton");
+  const alertsBadge = byId("adminAlertsBadge");
+  const alertsModal = byId("adminAlertsModal");
+  const alertsCloseBtn = byId("adminAlertsCloseBtn");
   const alertsList = byId("adminAlertsList");
+  const overviewOutcomeBtn = byId("adminOverviewOutcomeBtn");
   const demandStatusFilterEl = byId("adminDemandStatusFilter");
   const demandRefreshBtn = byId("adminDemandRefreshBtn");
   const demandCards = byId("adminDemandCards");
@@ -38,6 +40,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const adminOutcomeClearRangeBtn = byId("adminOutcomeClearRangeBtn");
   const adminOutcomeRefreshBtn = byId("adminOutcomeRefreshBtn");
   const adminOutcomeExportCsvBtn = byId("adminOutcomeExportCsvBtn");
+  const adminOutcomeBackBtn = byId("adminOutcomeBackBtn");
 
   const createUserForm = byId("adminCreateUserForm");
   const createRoleEl = byId("adminCreateRole");
@@ -66,15 +69,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const exportTxtBtn = byId("adminExportTxtBtn");
   const backupBtn = byId("adminBackupBtn");
 
-  const archiveStatusFilterEl = byId("adminArchiveStatusFilter");
-  const archiveJobFilterEl = byId("adminArchiveJobFilter");
-  const archiveTeacherFilterEl = byId("adminArchiveTeacherFilter");
-  const archiveStudentFilterEl = byId("adminArchiveStudentFilter");
-  const archiveApplyBtn = byId("adminArchiveApplyBtn");
-  const archiveResetBtn = byId("adminArchiveResetBtn");
-  const archiveExportCsvBtn = byId("adminArchiveExportCsvBtn");
-  const archiveExportTxtBtn = byId("adminArchiveExportTxtBtn");
-
   const changePasswordForm = byId("adminChangePasswordForm");
   const changePasswordBtn = byId("adminChangePasswordBtn");
   const announcementForm = byId("adminAnnouncementForm");
@@ -91,7 +85,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const currentUserName = portal?.getAttribute("data-current-user-name") || "Admin User";
 
   let latestData = null;
-  let latestArchive = null;
   let latestDemands = null;
   /** When set, workload table re-expands this student after dashboard reload (e.g. save threshold). */
   let openWorkloadStudentId = null;
@@ -104,14 +97,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     department: "all",
     teacher: "all"
   };
-  const archiveFilters = {
-    status: "all",
-    jobId: "all",
-    teacher: "all",
-    student: ""
-  };
   const demandFilters = {
-    status: "pending"
+    status: "all"
   };
   const RECRUITMENT_VACANCY_TOP = 10;
   const outcomeJobDateRange = { since: "", until: "" };
@@ -146,18 +133,32 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (tabName === "users") title.textContent = "User Management";
     if (tabName === "demands") title.textContent = "Demand Approval Workbench";
     if (tabName === "jobs") title.textContent = "Job Management";
-    if (tabName === "archive") title.textContent = "Application Archive";
-    if (tabName === "alerts") title.textContent = "Administrator Alerts";
     if (tabName === "announcements") {
       title.textContent = "System Announcements";
       void loadAnnouncements();
     }
     if (tabName === "account") title.textContent = "My Account";
     if (tabName === "overview") title.textContent = `Welcome, ${currentUserName}`;
-    if (tabName === "recruitment-outcome") {
-      title.textContent = "Recruitment Results (leadership view)";
-      void loadRecruitmentOutcome();
+    if (tabName === "recruitment-outcome") title.textContent = "Recruitment Results (leadership view)";
+  }
+
+  function openRecruitmentOutcome() {
+    tabs.forEach((tab) => {
+      tab.classList.remove("active");
+      tab.setAttribute("aria-selected", "false");
+    });
+    panels.forEach((panel) => {
+      panel.classList.toggle("admin-hidden", panel.getAttribute("data-admin-panel") !== "recruitment-outcome");
+    });
+    const portalMain = document.querySelector(".admin-portal-main");
+    if (portalMain) {
+      portalMain.classList.add("admin-portal-main--wide");
     }
+    const title = byId("adminSubTitle");
+    if (title) {
+      title.textContent = "Recruitment Results (leadership view)";
+    }
+    void loadRecruitmentOutcome();
   }
 
   function prefersReducedMotion() {
@@ -203,21 +204,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       .map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`)
       .join("");
     teacherFilterEl.value = filters.teacher;
-  }
-
-  function renderArchiveOptions(jobs) {
-    if (archiveJobFilterEl) {
-      archiveJobFilterEl.innerHTML = `<option value="all">All Jobs</option>` + (jobs || [])
-        .map((job) => `<option value="${escapeHtml(job.id)}">${escapeHtml(job.moduleCode || job.id)} - ${escapeHtml(job.title || "Untitled")}</option>`)
-        .join("");
-      archiveJobFilterEl.value = archiveFilters.jobId;
-    }
-    if (archiveTeacherFilterEl) {
-      archiveTeacherFilterEl.innerHTML = `<option value="all">All Teachers</option>` + knownTeachers
-        .map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`)
-        .join("");
-      archiveTeacherFilterEl.value = archiveFilters.teacher;
-    }
   }
 
   function buildRecruitmentOutcomeQueryParams() {
@@ -279,6 +265,35 @@ document.addEventListener("DOMContentLoaded", async () => {
         </div>
       </div>`;
     }).join("");
+  }
+
+  function renderRecruitmentMixChart(data) {
+    const chart = byId("adminOutcomeMixChart");
+    if (!chart) return;
+    const slots = Math.max(Number(data.totalPositionSlots) || 0, 0);
+    const hired = Math.max(Number(data.totalHired) || 0, 0);
+    const vacancies = Math.max(Number(data.totalVacancies) || 0, 0);
+    if (slots === 0 && hired === 0 && vacancies === 0) {
+      chart.innerHTML = `<p class="desc">No recruitment result data yet.</p>`;
+      return;
+    }
+    const total = Math.max(slots, hired + vacancies, 1);
+    const hiredDeg = Math.min(360, Math.round((hired / total) * 360));
+    const vacancyDeg = Math.min(360 - hiredDeg, Math.round((vacancies / total) * 360));
+    const spareDeg = Math.max(0, 360 - hiredDeg - vacancyDeg);
+    chart.innerHTML = `
+      <div class="admin-donut" style="--hired-deg:${hiredDeg}deg;--vacancy-deg:${vacancyDeg}deg;--spare-deg:${spareDeg}deg;" role="img" aria-label="Hired ${hired}, vacancies ${vacancies}, total slots ${slots}">
+        <div class="admin-donut-hole">
+          <strong>${escapeHtml(String(slots))}</strong>
+          <span>slots</span>
+        </div>
+      </div>
+      <div class="admin-donut-legend">
+        <span><i class="admin-dot admin-dot-hired"></i>Hired ${escapeHtml(String(hired))}</span>
+        <span><i class="admin-dot admin-dot-vacancy"></i>Vacancies ${escapeHtml(String(vacancies))}</span>
+        <span><i class="admin-dot admin-dot-capacity"></i>Total slots ${escapeHtml(String(slots))}</span>
+      </div>
+    `;
   }
 
   function recruitmentOutcomeDisplayCell(value) {
@@ -346,9 +361,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         genEl.textContent = formatOutcomeGeneratedAt(data.generatedAt);
       } else if (genEl) {
         genEl.removeAttribute("datetime");
-        genEl.textContent = "—";
+        genEl.textContent = "-";
       }
       renderRecruitmentDepartmentChart(data.departments);
+      renderRecruitmentMixChart(data);
       renderRecruitmentVacancyTable(data.topVacancyJobs, data.vacancyTopLimit);
     } catch (err) {
       setNotice(err.message, true);
@@ -376,7 +392,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         .sort((a, b) => a.localeCompare(b));
       renderDepartmentOptions();
       renderTeacherOptions();
-      renderArchiveOptions(latestData.jobs || []);
     }
 
     byId("statJobs").textContent = latestData.totalJobs ?? 0;
@@ -397,20 +412,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       return jobs;
     }
     return jobs.filter((job) => String(job.teacherName || "").trim() === filters.teacher);
-  }
-
-  async function loadArchive() {
-    const params = new URLSearchParams();
-    params.set("status", archiveFilters.status || "all");
-    params.set("jobId", archiveFilters.jobId || "all");
-    params.set("teacher", archiveFilters.teacher || "all");
-    if (archiveFilters.student) {
-      params.set("student", archiveFilters.student);
-    }
-    latestArchive = await requestJson(`${window.location.origin}${getContextPath()}/api/admin/applications?${params.toString()}`, {
-      method: "GET"
-    });
-    renderArchive((latestArchive && latestArchive.items) || []);
   }
 
   async function loadDemands() {
@@ -515,9 +516,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             </div>
             <p class="admin-demand-requirements">${escapeHtml(item.requirements || "No demand notes yet.")}</p>
             ${item.rejectionReason ? `<p class="admin-demand-reason"><strong>Reject reason:</strong> ${escapeHtml(item.rejectionReason)}</p>` : ""}
-            <div class="row" style="margin-top:12px;">
-              ${demandActionButtons(item)}
-            </div>
+            ${demandDecisionControl(item)}
           </article>
         `;
       }).join("") || `<div class="card"><p class="admin-empty-text">No demands found for this status.</p></div>`;
@@ -531,19 +530,25 @@ document.addEventListener("DOMContentLoaded", async () => {
           <td>${escapeHtml(item.teacherName || item.moId || "-")}</td>
           <td>${escapeHtml(formatDate(item.createdAt) || "-")}</td>
           <td>${escapeHtml(formatStatus(item.approvalStatus))}</td>
-          <td>${demandActionButtons(item)}</td>
+          <td>${demandDecisionControl(item, true)}</td>
         </tr>
       `).join("") || `<tr><td colspan="6">No demands found for this status.</td></tr>`;
     }
   }
 
-  function demandActionButtons(item) {
-    if (String(item.approvalStatus || "").toLowerCase() !== "pending") {
-      return `<span class="admin-list-meta">Reviewed ${escapeHtml(formatDate(item.reviewedAt) || "-")}</span>`;
-    }
+  function demandDecisionControl(item, compact) {
+    const status = String(item.approvalStatus || "pending").toLowerCase();
+    const reason = item.rejectionReason || "";
     return `
-      <button class="btn btn-primary" type="button" data-demand-review="${escapeHtml(item.jobId)}" data-demand-action="approve">Approve</button>
-      <button class="btn btn-outline" type="button" data-demand-review="${escapeHtml(item.jobId)}" data-demand-action="reject">Reject</button>
+      <div class="admin-demand-review-control ${compact ? "admin-demand-review-control--compact" : ""}" data-demand-control="${escapeHtml(item.jobId)}">
+        <select data-demand-status="${escapeHtml(item.jobId)}" aria-label="Demand approval status">
+          <option value="pending" ${status === "pending" ? "selected" : ""}>Pending</option>
+          <option value="approved" ${status === "approved" ? "selected" : ""}>Approved</option>
+          <option value="rejected" ${status === "rejected" ? "selected" : ""}>Rejected</option>
+        </select>
+        <input type="text" maxlength="200" data-demand-reason="${escapeHtml(item.jobId)}" placeholder="Reject reason" value="${escapeHtml(reason)}" ${status === "rejected" ? "" : "disabled"} />
+        <button class="btn btn-primary" type="button" data-demand-review="${escapeHtml(item.jobId)}">Save</button>
+      </div>
     `;
   }
 
@@ -950,6 +955,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (event.key !== "Escape") {
       return;
     }
+    if (alertsModal && !alertsModal.classList.contains("admin-hidden")) {
+      closeAlertsModal();
+      event.preventDefault();
+      return;
+    }
     if (event.target.closest("input, textarea, select, option, [contenteditable='true']")) {
       return;
     }
@@ -995,10 +1005,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   function renderAlerts(alerts) {
     const items = Array.isArray(alerts) ? alerts : [];
-    const previewItems = items.slice(0, 4);
-    if (alertsPreview) {
-      alertsPreview.innerHTML = previewItems.map(alertHtml).join("")
-        || `<div class="admin-alert admin-alert-info"><strong>No alerts</strong><p>No active admin alerts.</p></div>`;
+    if (alertsBadge) {
+      alertsBadge.textContent = String(items.length);
+      alertsBadge.classList.toggle("is-empty", items.length === 0);
+    }
+    if (alertsButton) {
+      alertsButton.classList.toggle("has-alerts", items.length > 0);
     }
     if (alertsList) {
       alertsList.innerHTML = items.map(alertHtml).join("")
@@ -1020,40 +1032,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     `;
   }
 
-  function renderArchive(items) {
-    const rows = Array.isArray(items) ? items : [];
-    if (archiveCards) {
-      archiveCards.innerHTML = rows.map((item) => `
-        <article class="card admin-archive-card">
-          <div class="admin-job-title-line">
-            <h3 class="admin-job-title">${escapeHtml(item.moduleCode || item.jobId || "-")} - ${escapeHtml(item.title || "Unknown Job")}</h3>
-            <span class="tag ${archiveStatusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
-          </div>
-          <p class="admin-list-meta">Student: ${escapeHtml(item.studentName || item.studentId || "-")} - Organiser: ${escapeHtml(item.teacherName || "-")} - Applied: ${escapeHtml(formatDate(item.appliedAt) || "-")}</p>
-          <div class="admin-archive-notes">
-            <div><span class="admin-key">Evaluation Notes</span><p>${escapeHtml(item.evaluationNotes || "-")}</p></div>
-            <div><span class="admin-key">Decision Feedback</span><p>${escapeHtml(item.decisionFeedback || "-")}</p></div>
-          </div>
-        </article>
-      `).join("") || `<div class="card"><p class="admin-empty-text">No archived applications found.</p></div>`;
-    }
-
-    if (archiveBody) {
-      archiveBody.innerHTML = rows.map((item) => `
-        <tr>
-          <td>${escapeHtml(item.applicationId || "-")}</td>
-          <td>${escapeHtml(item.studentName || item.studentId || "-")}</td>
-          <td>${escapeHtml(item.moduleCode || item.jobId || "-")}</td>
-          <td>${escapeHtml(item.teacherName || "-")}</td>
-          <td>${escapeHtml(formatStatus(item.status))}</td>
-          <td>${escapeHtml(formatDate(item.appliedAt) || "-")}</td>
-          <td>${escapeHtml(item.decisionFeedback || item.evaluationNotes || "-")}</td>
-        </tr>
-      `).join("") || `<tr><td colspan="7">No archived applications found.</td></tr>`;
-    }
-  }
-
-  function archiveStatusClass(status) {
+  function applicationStatusClass(status) {
     const value = String(status || "").toLowerCase();
     if (value === "hired") return "ok";
     if (value === "rejected") return "danger";
@@ -1101,10 +1080,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         <article class="card admin-app-card">
           <div class="admin-job-title-line">
             <h3 class="admin-subtitle">${escapeHtml(item.studentName || item.studentId || "-")}</h3>
-            <span class="tag ${archiveStatusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
+            <span class="tag ${applicationStatusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
           </div>
           <p class="admin-list-meta">Student No: ${escapeHtml(item.studentNo || "-")} | Applied: ${escapeHtml(formatDate(item.appliedAt) || "-")}</p>
-          <div class="admin-archive-notes">
+          <div class="admin-application-notes">
             <div><span class="admin-key">Evaluation Notes</span><p>${escapeHtml(item.evaluationNotes || "-")}</p></div>
             <div><span class="admin-key">Decision Feedback</span><p>${escapeHtml(item.decisionFeedback || "-")}</p></div>
           </div>
@@ -1291,35 +1270,34 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function reviewDemand(button) {
     const jobId = button.getAttribute("data-demand-review");
-    const action = button.getAttribute("data-demand-action");
-    if (!jobId || !action) {
+    const control = button.closest("[data-demand-control]");
+    const statusEl = control ? control.querySelector("[data-demand-status]") : null;
+    const reasonEl = control ? control.querySelector("[data-demand-reason]") : null;
+    const nextStatus = statusEl ? statusEl.value : "";
+    if (!jobId || !nextStatus) {
       return;
     }
-    let reason = "";
-    if (action === "reject") {
-      const entered = window.prompt("Enter a short rejection reason (optional):", "");
-      if (entered === null) {
-        return;
-      }
-      reason = entered.trim();
+    const action = nextStatus === "approved" ? "approve" : (nextStatus === "rejected" ? "reject" : "pending");
+    const reason = nextStatus === "rejected" && reasonEl ? reasonEl.value.trim() : "";
+    if (nextStatus === "rejected") {
       if (reason.length > 200) {
         setNotice("Rejection reason must be 200 characters or fewer.", true);
         activateTab("demands");
         return;
       }
-    } else if (!window.confirm(`Approve demand ${jobId}?`)) {
+    } else if (!window.confirm(`Set demand ${jobId} to ${nextStatus}?`)) {
       return;
     }
 
     try {
       button.disabled = true;
-      button.textContent = action === "approve" ? "Approving..." : "Rejecting...";
+      button.textContent = "Saving...";
       await requestJson(`${window.location.origin}${getContextPath()}/api/admin/demands/review/${encodeURIComponent(jobId)}?action=${encodeURIComponent(action)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json;charset=UTF-8" },
         body: JSON.stringify({ reason })
       });
-      setNotice(`Demand ${jobId} ${action === "approve" ? "approved" : "rejected"}.`, false);
+      setNotice(`Demand ${jobId} set to ${nextStatus}.`, false);
       await Promise.all([loadDemands(), loadAdminDashboard()]);
       activateTab("demands");
     } catch (err) {
@@ -1327,7 +1305,25 @@ document.addEventListener("DOMContentLoaded", async () => {
       activateTab("demands");
     } finally {
       button.disabled = false;
-      button.textContent = action === "approve" ? "Approve" : "Reject";
+      button.textContent = "Save";
+    }
+  }
+
+  function openAlertsModal() {
+    if (!alertsModal) return;
+    alertsModal.classList.remove("admin-hidden");
+    document.body.classList.add("admin-modal-open");
+    if (alertsCloseBtn) {
+      alertsCloseBtn.focus();
+    }
+  }
+
+  function closeAlertsModal() {
+    if (!alertsModal) return;
+    alertsModal.classList.add("admin-hidden");
+    document.body.classList.remove("admin-modal-open");
+    if (alertsButton) {
+      alertsButton.focus();
     }
   }
 
@@ -1404,27 +1400,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       defaultText,
       "Recruitment outcome CSV exported.",
       "recruitment-outcome"
-    );
-  }
-
-  async function downloadArchiveReport(format) {
-    const button = format === "csv" ? archiveExportCsvBtn : archiveExportTxtBtn;
-    const defaultText = format === "csv" ? "Export Archive CSV" : "Export Archive TXT";
-    const params = new URLSearchParams();
-    params.set("format", format);
-    params.set("status", archiveFilters.status || "all");
-    params.set("jobId", archiveFilters.jobId || "all");
-    params.set("teacher", archiveFilters.teacher || "all");
-    if (archiveFilters.student) {
-      params.set("student", archiveFilters.student);
-    }
-    await downloadAdminFile(
-      `/api/admin/reports/applications?${params.toString()}`,
-      `application-archive.${format}`,
-      button,
-      defaultText,
-      `Application archive ${format.toUpperCase()} exported.`,
-      "archive"
     );
   }
 
@@ -1541,40 +1516,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     return String(value || "all").trim().replace(/[^A-Za-z0-9_-]+/g, "-") || "all";
   }
 
-  async function applyArchiveFilters() {
-    archiveFilters.status = archiveStatusFilterEl.value || "all";
-    archiveFilters.jobId = archiveJobFilterEl.value || "all";
-    archiveFilters.teacher = archiveTeacherFilterEl.value || "all";
-    archiveFilters.student = archiveStudentFilterEl.value.trim();
-    try {
-      await loadArchive();
-      setNotice("Archive filters applied.", false);
-      activateTab("archive");
-    } catch (err) {
-      setNotice(err.message, true);
-      activateTab("archive");
-    }
-  }
-
-  async function resetArchiveFilters() {
-    archiveFilters.status = "all";
-    archiveFilters.jobId = "all";
-    archiveFilters.teacher = "all";
-    archiveFilters.student = "";
-    archiveStatusFilterEl.value = "all";
-    archiveJobFilterEl.value = "all";
-    archiveTeacherFilterEl.value = "all";
-    archiveStudentFilterEl.value = "";
-    try {
-      await loadArchive();
-      setNotice("Archive filters reset.", false);
-      activateTab("archive");
-    } catch (err) {
-      setNotice(err.message, true);
-      activateTab("archive");
-    }
-  }
-
   async function changeOwnPassword(event) {
     event.preventDefault();
     const oldPassword = byId("adminOldPassword").value.trim();
@@ -1676,6 +1617,23 @@ document.addEventListener("DOMContentLoaded", async () => {
     reviewDemand(reviewButton);
   }
 
+  function handleDemandStatusChange(event) {
+    const statusSelect = event.target.closest("[data-demand-status]");
+    if (!statusSelect) {
+      return;
+    }
+    const control = statusSelect.closest("[data-demand-control]");
+    const reasonInput = control ? control.querySelector("[data-demand-reason]") : null;
+    if (!reasonInput) {
+      return;
+    }
+    const rejected = statusSelect.value === "rejected";
+    reasonInput.disabled = !rejected;
+    if (!rejected) {
+      reasonInput.value = "";
+    }
+  }
+
   function onJobDetails(event) {
     const btn = event.target.closest("[data-job-details]");
     if (!btn || !jobsCards.contains(btn)) return;
@@ -1743,6 +1701,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   usersGrouped.addEventListener("click", handleUserActions);
   if (demandCards) demandCards.addEventListener("click", handleDemandActions);
   if (demandBody) demandBody.addEventListener("click", handleDemandActions);
+  if (demandCards) demandCards.addEventListener("change", handleDemandStatusChange);
+  if (demandBody) demandBody.addEventListener("change", handleDemandStatusChange);
   jobsBody.addEventListener("click", onJobsTableClick);
   jobsCards.addEventListener("click", onJobsCardsClick);
   workloadBody.addEventListener("click", onWorkloadTableClick);
@@ -1753,6 +1713,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   tabs.forEach((tab) => {
     tab.addEventListener("click", () => activateTab(tab.getAttribute("data-admin-tab")));
   });
+  if (overviewOutcomeBtn) overviewOutcomeBtn.addEventListener("click", openRecruitmentOutcome);
+  if (adminOutcomeBackBtn) adminOutcomeBackBtn.addEventListener("click", () => activateTab("overview"));
+  if (alertsButton) alertsButton.addEventListener("click", openAlertsModal);
+  if (alertsModal) {
+    alertsModal.addEventListener("click", (event) => {
+      if (event.target.closest("[data-alerts-close]")) {
+        closeAlertsModal();
+      }
+    });
+  }
   createRoleEl.addEventListener("change", syncCreateRoleFields);
   createUserForm.addEventListener("submit", createUser);
   thresholdForm.addEventListener("submit", saveThreshold);
@@ -1764,10 +1734,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   exportWorkloadCsvBtn.addEventListener("click", () => downloadWorkloadReport("csv"));
   exportWorkloadTxtBtn.addEventListener("click", () => downloadWorkloadReport("txt"));
   backupBtn.addEventListener("click", downloadBackup);
-  archiveApplyBtn.addEventListener("click", applyArchiveFilters);
-  archiveResetBtn.addEventListener("click", resetArchiveFilters);
-  archiveExportCsvBtn.addEventListener("click", () => downloadArchiveReport("csv"));
-  archiveExportTxtBtn.addEventListener("click", () => downloadArchiveReport("txt"));
   if (jobApplicationsApplyBtn) jobApplicationsApplyBtn.addEventListener("click", applyJobApplicationFilter);
   if (jobApplicationsCloseBtn) jobApplicationsCloseBtn.addEventListener("click", closeJobApplications);
   if (jobApplicationsCsvBtn) jobApplicationsCsvBtn.addEventListener("click", () => downloadJobApplications("csv"));
@@ -1801,7 +1767,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   syncCreateRoleFields();
   activateTab("overview");
   try {
-    await Promise.all([loadAdminDashboard(), loadThresholdSettings(), loadArchive(), loadDemands()]);
+    await Promise.all([loadAdminDashboard(), loadThresholdSettings(), loadDemands()]);
   } catch (err) {
     setNotice(err.message, true);
   }

--- a/web/src/main/webapp/pages/admin.jsp
+++ b/web/src/main/webapp/pages/admin.jsp
@@ -28,9 +28,29 @@
           <p id="adminSubTitle">Welcome, <%= currentUserName %></p>
         </div>
       </div>
-      <a class="admin-btn-logout" href="<%= request.getContextPath() %>/logout">Logout</a>
+      <div class="admin-header-actions">
+        <button id="adminAlertsButton" class="admin-alert-trigger" type="button" aria-haspopup="dialog" aria-controls="adminAlertsModal" aria-label="Open administrator alerts">
+          <span aria-hidden="true">!</span>
+          <strong id="adminAlertsBadge">0</strong>
+        </button>
+        <a class="admin-btn-logout" href="<%= request.getContextPath() %>/logout">Logout</a>
+      </div>
     </div>
   </header>
+
+  <div id="adminAlertsModal" class="admin-modal admin-hidden" role="dialog" aria-modal="true" aria-labelledby="adminAlertsModalTitle">
+    <div class="admin-modal-backdrop" data-alerts-close></div>
+    <div class="admin-modal-card admin-alert-modal-card">
+      <div class="admin-modal-head">
+        <div>
+          <h2 id="adminAlertsModalTitle" class="admin-section-title">Administrator Alerts</h2>
+          <p class="admin-section-desc">Workload, vacancy, deadline, and data-quality risk cases.</p>
+        </div>
+        <button id="adminAlertsCloseBtn" type="button" class="btn btn-outline" data-alerts-close>Close</button>
+      </div>
+      <div id="adminAlertsList" class="admin-alert-list"></div>
+    </div>
+  </div>
 
   <main class="admin-portal-main">
     <nav class="admin-tabs" role="tablist" aria-label="Admin sections">
@@ -39,9 +59,6 @@
       <button class="admin-tab" data-admin-tab="users" role="tab" aria-selected="false">Users</button>
       <button class="admin-tab" data-admin-tab="demands" role="tab" aria-selected="false">Demand Review</button>
       <button class="admin-tab" data-admin-tab="jobs" role="tab" aria-selected="false">Jobs</button>
-      <button class="admin-tab admin-tab--outcome" data-admin-tab="recruitment-outcome" role="tab" aria-selected="false">Recruitment Results</button>
-      <button class="admin-tab" data-admin-tab="archive" role="tab" aria-selected="false">Application Archive</button>
-      <button class="admin-tab" data-admin-tab="alerts" role="tab" aria-selected="false">Alerts</button>
       <button class="admin-tab" data-admin-tab="announcements" role="tab" aria-selected="false">Announcements</button>
       <button class="admin-tab" data-admin-tab="account" role="tab" aria-selected="false">My Account</button>
     </nav>
@@ -85,7 +102,7 @@
 
       <div class="card">
         <h3 class="admin-subtitle">Quick Summary</h3>
-        <p class="desc">Use the tabs above to manage workload, users, jobs, archive, and alerts.</p>
+        <p class="desc">Use the tabs above to manage workload, users, jobs, demand review, and announcements.</p>
         <div class="admin-summary-grid">
           <div class="admin-summary-item">
             <span id="overviewOpenJobs">0</span>
@@ -112,11 +129,9 @@
             <small>Active Alerts</small>
           </div>
         </div>
-      </div>
-
-      <div class="card" style="margin-top:16px;">
-        <h3 class="admin-subtitle">Priority Alerts</h3>
-        <div id="adminAlertsPreview" class="admin-alert-list"></div>
+        <div class="row" style="margin-top:16px;">
+          <button id="adminOverviewOutcomeBtn" type="button" class="btn btn-primary">View Recruitment Results</button>
+        </div>
       </div>
     </section>
 
@@ -242,10 +257,10 @@
           <div class="field">
             <label for="adminDemandStatusFilter">Approval Status</label>
             <select id="adminDemandStatusFilter">
+              <option value="all">All</option>
               <option value="pending">Pending</option>
               <option value="approved">Approved</option>
               <option value="rejected">Rejected</option>
-              <option value="all">All</option>
             </select>
           </div>
         </div>
@@ -258,7 +273,7 @@
         <h3 class="admin-subtitle">Demand Review Table</h3>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Module</th><th>Title</th><th>Organiser</th><th>Submitted</th><th>Status</th><th>Action</th></tr></thead>
+            <thead><tr><th>Module</th><th>Title</th><th>Organiser</th><th>Submitted</th><th>Current Status</th><th>Review Decision</th></tr></thead>
             <tbody id="adminDemandBody"></tbody>
           </table>
         </div>
@@ -371,6 +386,7 @@
               </div>
             </div>
             <div class="admin-outcome-toolbar-actions">
+              <button type="button" id="adminOutcomeBackBtn" class="btn btn-outline">Back to Overview</button>
               <button type="button" id="adminOutcomeApplyRangeBtn" class="btn btn-primary">Apply range</button>
               <button type="button" id="adminOutcomeClearRangeBtn" class="btn btn-outline">All jobs</button>
               <button type="button" id="adminOutcomeRefreshBtn" class="btn btn-outline">Refresh snapshot</button>
@@ -418,6 +434,11 @@
         </article>
       </div>
       <div class="card admin-outcome-card">
+        <h3 class="admin-subtitle">Overall hiring mix</h3>
+        <p class="desc">Visual split of hired seats and remaining vacancies against total position slots.</p>
+        <div id="adminOutcomeMixChart" class="admin-outcome-mix-chart"></div>
+      </div>
+      <div class="card admin-outcome-card">
         <h3 class="admin-subtitle">By department</h3>
         <p class="desc">Hired counts and unfilled slots grouped by each job posting's department field. Blank values are rolled up as 未填.</p>
         <p class="admin-outcome-dept-legend" role="note">
@@ -448,73 +469,6 @@
         </div>
       </div>
       </div>
-    </section>
-
-    <section class="admin-panel admin-hidden" data-admin-panel="archive">
-      <div class="admin-headline">
-        <div>
-          <h2 class="admin-section-title">Application Archive</h2>
-          <p class="admin-section-desc">Read-only audit view of applications, MO notes, and decision feedback.</p>
-        </div>
-      </div>
-      <div class="card" style="margin-bottom:16px;">
-        <h3 class="admin-subtitle">Archive Filters and Export</h3>
-        <div class="admin-form-grid">
-          <div class="field">
-            <label for="adminArchiveStatusFilter">Status</label>
-            <select id="adminArchiveStatusFilter">
-              <option value="all">All</option>
-              <option value="pending">Pending</option>
-              <option value="viewed">Viewed</option>
-              <option value="shortlisted">Shortlisted</option>
-              <option value="hired">Hired</option>
-              <option value="rejected">Rejected</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="adminArchiveJobFilter">Job</label>
-            <select id="adminArchiveJobFilter">
-              <option value="all">All Jobs</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="adminArchiveTeacherFilter">Module Organiser</label>
-            <select id="adminArchiveTeacherFilter">
-              <option value="all">All Teachers</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="adminArchiveStudentFilter">Student Search</label>
-            <input id="adminArchiveStudentFilter" type="text" placeholder="Name, user ID, or student no." />
-          </div>
-        </div>
-        <div class="row" style="margin-top:16px;">
-          <button id="adminArchiveApplyBtn" type="button" class="btn btn-primary">Apply Archive Filters</button>
-          <button id="adminArchiveResetBtn" type="button" class="btn btn-outline">Reset</button>
-          <button id="adminArchiveExportCsvBtn" type="button" class="btn btn-outline">Export Archive CSV</button>
-          <button id="adminArchiveExportTxtBtn" type="button" class="btn btn-outline">Export Archive TXT</button>
-        </div>
-      </div>
-      <div id="adminArchiveCards" class="admin-feed"></div>
-      <div class="card">
-        <h3 class="admin-subtitle">Archive Table</h3>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th>Application</th><th>Student</th><th>Job</th><th>Organiser</th><th>Status</th><th>Applied</th><th>Feedback</th></tr></thead>
-            <tbody id="adminArchiveBody"></tbody>
-          </table>
-        </div>
-      </div>
-    </section>
-
-    <section class="admin-panel admin-hidden" data-admin-panel="alerts">
-      <div class="admin-headline">
-        <div>
-          <h2 class="admin-section-title">Administrator Alerts</h2>
-          <p class="admin-section-desc">Follow up workload, vacancy, deadline, and data-quality risk cases.</p>
-        </div>
-      </div>
-      <div id="adminAlertsList" class="admin-alert-list"></div>
     </section>
 
     <section class="admin-panel admin-hidden" data-admin-panel="announcements">


### PR DESCRIPTION
## Summary
- Add editable demand review decisions for pending / approved / rejected status.
- Move Recruitment Results from a top-level tab into System Overview and add chart-based result views.
- Remove the standalone Application Archive page while keeping job-level application drilldown.
- Move Admin Alerts into a header alert modal next to Logout.

## Testing
- node --check web/src/main/webapp/assets/js/admin.js
- mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" -DskipTests compile
