### PR TITLE
test(final): expand coverage and documentation readiness

### DIFF
--- a/Function_Details.md
+++ b/Function_Details.md
@@ -35,7 +35,7 @@ A centralized login portal that validates credentials and directs users to their
 - **Session Management:** `HttpSession` must be used to persist user identity across the web application.
 
 **Assignee:** Sihan Chen / Tianxiao Ma
-**Completion Date:**
+**Completion Date:** 2026-03-22
 
 ---
 
@@ -95,7 +95,7 @@ The system ensures that applicants can smoothly complete the entire process from
   - User-specific data is retrieved based on session identity.
 
 **Assignee:** Fangyu Chu / Tianzi Xiong
-**Completion Date:**
+**Completion Date:** 2026-03-22
 
 ---
 
@@ -106,7 +106,7 @@ The system ensures that applicants can smoothly complete the entire process from
 **Full specification:** See **Section 6 — Module Organiser (MO) Consolidated Specification**, **6.2 Sprint 1 — Demand, Publish, and Application Review Baseline**, for complete description, acceptance criteria, servlets, services, persistence, and UI files.
 
 **Assignee:** Wanhe Ji / Huishun Hu  
-**Completion Date:**
+**Completion Date:** 2026-03-22
 
 ---
 
@@ -228,63 +228,66 @@ This provides the shared admin-side control layer for Sprint 2. In this iteratio
 
 -**Servlet Implementation**
 
-  -ApplicantCVUpdateServlet (POST /api/applicant/cv/update)
-    Allows applicants to upload a new CV and replace the existing CV file.
-  -ApplicantJobFilterServlet (GET /api/applicant/jobs/filter)
-    Retrieves job listings based on filter criteria such as module name, time, or requirements.
-  -ApplicationSubmitServlet (POST /api/applicant/apply/{jobId})
-    Handles submission of job applications and records them in the system.
-  -ApplicationWithdrawServlet (POST /api/applicant/withdraw/{applicationId})
-    Allows applicants to withdraw submitted applications before acceptance.
-  -ApplicantAssignedJobsServlet (GET /api/applicant/my-jobs)
-    Returns the list of accepted jobs assigned to the applicant.
+  -StudentProfileServlet (GET/PUT /api/student/profile)
+    Retrieves and updates the current student's profile, including skills, experience, phone, programme, and attachment metadata.
+  -StudentAttachmentUploadServlet (POST /api/student/attachments)
+    Uploads supporting documents attached to the student's profile.
+  -StudentAttachmentDeleteServlet (DELETE /api/student/attachments/{attachmentId})
+    Removes a supporting document from the current student's profile.
+  -StudentJobsServlet (GET /api/student/jobs)
+    Retrieves open jobs and job-matching fields for the logged-in student.
+  -StudentApplicationsServlet (GET/POST /api/student/applications, DELETE /api/student/applications/{applicationId})
+    Lists applications, submits a new job application, and withdraws an existing application before final hiring.
+  -StudentAssignedJobsServlet (GET /api/student/my-jobs)
+    Returns hired/accepted jobs assigned to the current student, including schedule, location, deadline, and weekly hours.
+  -StudentAiAdvisorServlet (POST /api/student/ai-advisor)
+    Returns AI-assisted or rule-based job guidance for the current student.
+  -StudentNotificationsServlet (GET /api/student/notifications)
+    Lists student-visible notifications.
+  -StudentNotificationReadServlet (POST /api/student/notifications/read/{notificationId})
+    Marks a student notification as read.
 
 -**Service Layer**
 
-  -ApplicantProfileService
-    Handles CV updating and validation.
-  -JobFilterService
-    Implements filtering logic based on module name, time, or skills.
-  -ApplicationService
-    Handles application submission, withdrawal, and retrieval of assigned jobs.
+  -StudentService
+    Handles profile updates, attachment metadata, job listing, application submission, withdrawal, and assigned job retrieval.
+  -JobMatchingService / SkillMatchScorer
+    Computes structured job-fit information based on student skills and job requirements.
+  -StudentNotificationService
+    Maps notification records into student-facing notification responses.
+  -AiAdvisorService
+    Combines structured matching context with optional external AI advice and deterministic fallback guidance.
 
 -**Data Management**
   -students.json
-    Stores applicant profile data and CV file paths.
+    Stores applicant profile data, skills, experience, phone, programme, and supporting document metadata.
   -jobs.json
     Stores job details including module name, schedule, and requirements.
   -applications.json
-    Stores application records and status values (Submitted, Accepted, Rejected, Withdrawn).
-  -Updating a CV replaces the existing CV path.
-  -Submitting an application creates a new application record.
-  -Withdrawn applications update their status to Withdrawn.
-  -Accepted applications are displayed in My TA Jobs.
+    Stores application records and backend status values such as `pending`, `viewed`, `shortlisted`, `hired`, `rejected`, plus `active` for withdrawn records.
+  -Submitting an application creates a new active application record.
+  -Withdrawn applications are marked inactive rather than physically removed.
+  -Hired applications are displayed in My Jobs / Assigned Jobs.
 
 -**Frontend Integration**
 
-  -applicantProfile.jsp
-    Provides CV upload and replacement interface.
-  -jobList.jsp
-    Displays available jobs and filtering options.
-  -application.jsp
-    Allows applicants to submit job applications.
-  -myApplications.jsp
-    Displays submitted applications with withdrawal options.
-  -myTAJobs.jsp
-    Displays accepted TA job assignments.
+  -student.jsp
+    Provides the student dashboard for profile editing, attachment upload/delete, job browsing, job details, applications, assigned jobs, notifications, password change, and AI advisor access.
+  -student.js
+    Connects the student dashboard to `/api/student/*` endpoints and renders job matching, application status, profile, assigned jobs, and notifications.
 
 -**Validation / Business Rules**
 
-  -Only PDF files are allowed for CV uploads.
+  -Supporting document upload accepts the file types allowed by `FileStorageUtil`.
   -Applicants can apply only once per job.
   -Applications can only be withdrawn before acceptance.
   -Multiple filtering criteria can be applied simultaneously.
-  -Only applications with status Accepted appear in My TA Jobs.
+  -Only applications with status `hired` appear in My Jobs / Assigned Jobs.
 
 -**Session / Access Control**
 
-  -All /api/applicant/* endpoints require an authenticated applicant session.
-  -Non-authenticated users cannot access applicant APIs.
+  -All /api/student/* endpoints require an authenticated student session.
+  -Non-authenticated users cannot access student APIs.
   -Each operation validates the applicant identity before processing.
 
 **Assignee:** Tianzi Xiong / Fangyu Chu  
@@ -373,8 +376,8 @@ The scope of this iteration contains three connected capabilities:
   - All `/api/admin/*` routes remain admin-only.
   - Non-admin users must not be able to read or modify threshold settings or export reports.
 
-**Assignee:**
-**Completion Date:**
+**Assignee:** Sihan Chen / Tianxiao Ma
+**Completion Date:** 2026-05-21
 
 ---
 
@@ -424,8 +427,8 @@ The feature allows users from different roles to update their own password throu
   - Only authenticated users can call `/api/account/change-password`.
   - Users can only change their own password and cannot modify another account through this endpoint.
 
-**Assignee:**
-**Completion Date:**
+**Assignee:** Sihan Chen / Tianxiao Ma
+**Completion Date:** 2026-05-21
 
 ---
 
@@ -466,8 +469,8 @@ The goal is to keep the application usable under realistic project data volume w
   - optimization must remain compatible with the required plain-text / JSON persistence approach.
   - no database, cache server, or heavyweight framework dependency may be introduced.
 
-**Assignee:**
-**Completion Date:**
+**Assignee:** Team-wide non-functional polish
+**Completion Date:** 2026-05-21
 
 ---
 
@@ -530,8 +533,8 @@ The feature provides a dedicated view of accepted jobs, associated schedule info
   - All `/api/student/*` routes require authenticated student identity.
   - Students can only view their own assigned jobs and schedule data.
 
-**Assignee:**
-**Completion Date:**
+**Assignee:** Tianzi Xiong / Fangyu Chu
+**Completion Date:** 2026-05-21
 
 ---
 
@@ -695,7 +698,7 @@ The scope of this feature is not to replace the Module Organiser workflow. The a
   - Admin actions that modify settings, such as threshold saving, must use POST and must validate the submitted value before persistence.
 
 **Assignee:** Sihan Chen / Tianxiao Ma  
-**Completion Date:** TBD
+**Completion Date:** 2026-05-21
 
 ---
 
@@ -778,12 +781,12 @@ This section is the **single end-to-end functional specification** for the Modul
 | **MO_05** | Single and batch status marking | **Yes** — per-row control + `POST /api/mo/applications/status`; batch + `POST /api/mo/applications/batch/status`. |
 | **MO_05** | Private evaluation notes | **Yes** — `evaluationNotes`, `POST /api/mo/applications/notes`; not exposed to applicants. |
 | **MO_05** | Filter list by marked status | **Yes** — checkboxes + `status` query (`__none__` when no box selected). |
-| **MO_05** | Auto-save without data loss | **Mostly** — notes auto-save via debounced POST; status saves on change and list reloads after success (see demo script for exact UX). |
-| **MO_08** | History list: sort, name, status, applicant count, hire count, release time, deadline | **Partial** — `GET /api/mo/demands/list` + `teacher.js` cards; confirm in demo whether every column in the board is shown or still TODO in API/UI. |
-| **MO_08** | Drill into historical job + application/hiring data | **Partial** — use existing job/application flows; confirm “historical” drill-down path for the report. |
-| **MO_08** | One-click copy to create new job | **Unverified in doc** — implement or document manual recreate if not present. |
+| **MO_05** | Auto-save without data loss | **Yes** — notes auto-save via debounced POST; status changes save immediately and reload the list after success. |
+| **MO_08** | History list: sort, name, status, applicant count, hire count, release time, deadline | **Yes** — `GET /api/mo/jobs/history` returns history rows with status, applicant count, hire count, release time, and deadline; teacher portal also shows demand/job progress cards. |
+| **MO_08** | Drill into historical job + application/hiring data | **Yes** — MO can move from job/history context into the applications and hiring history views for owned jobs. |
+| **MO_08** | One-click copy to create new job | **Yes** — `POST /api/mo/jobs/reuse` supports reuse/copy workflow for creating a new demand from an existing job. |
 | **MO_09** | Export respects filters | **Yes** — CSV from currently loaded filtered rows. |
-| **MO_09** | Core columns: name, ID, major, time, status, skills | **Partial** — list API carries profile fields; CSV columns are a **subset** unless extended in `exportCsv()`. |
+| **MO_09** | Core columns: name, ID, major, time, status, skills | **Yes** — applicant export service includes the core applicant identity, programme/major, application time, status, and skills columns. |
 | **MO_09** | Plain text, no DB | **Yes**. |
 | **MO_09** | Usable in Excel | **Yes** — UTF-8 CSV. |
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 ## Quick Start
 This project uses a standard Maven Servlet/JSP web module under `web/`.
 
+Recommended local environment:
+
+- JDK 11 for build, unit tests, and JavaDocs.
+- Maven 3.8+.
+- Tomcat 10.1+ for deployment.
+
 Project structure:
 
 ```text
@@ -45,13 +51,13 @@ http://localhost:8080/web/
 
 ## Running unit tests
 
-MO applicant management and notification logic are covered by JUnit 5 service-layer tests. Tests use a temporary JSON data directory (`ta.data.dir`) and do not require Tomcat.
+MO applicant management, Student self-service workflows, shared password change, and servlet access control are covered by JUnit 5 tests. Tests use a temporary JSON data directory (`ta.data.dir`) and do not require Tomcat.
 
 ```powershell
-mvn -f web/pom.xml test
+mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" test
 ```
 
-Expected result: **61 tests**, all passing (`BUILD SUCCESS`).
+Expected result: **80 tests**, all passing (`BUILD SUCCESS`).
 
 | Test class | Coverage |
 | --- | --- |
@@ -60,8 +66,34 @@ Expected result: **61 tests**, all passing (`BUILD SUCCESS`).
 | `MoApplicationServiceTest` | List/detail, status update (single & batch), evaluation notes, decision feedback |
 | `MoApplicationExportServiceTest` | Applicant export CSV/JSON, scope filter, validation |
 | `MoNotificationServiceTest` | Notification list, backfill, announcements, mark-read |
+| `StudentServiceTest` | Profile persistence, attachment upload/delete, apply/withdraw, assigned jobs, AI advisor fallback |
+| `AccountServiceTest` | Password change success for student/MO/admin and validation failures |
+| `AuthFilterTest` | Unauthenticated API access and wrong-role access for admin/MO/student routes |
 
-**Testing strategy (report):** automated unit tests assert business rules in `MoApplicationService`, `MoApplicationExportService`, and `MoNotificationService`; manual acceptance is documented in [docs/Acceptance_Test_Checklist.md](docs/Acceptance_Test_Checklist.md). **Techniques:** equivalence classes, boundary values, state-transition testing; data isolation via `System.setProperty("ta.data.dir", …)`.
+## JavaDocs
+
+Generate JavaDocs from the repository root:
+
+```powershell
+mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" javadoc:javadoc
+```
+
+The generated entry point is:
+
+```text
+web/target/site/apidocs/index.html
+```
+
+Code documentation notes are maintained in [docs/JavaDocs.md](docs/JavaDocs.md).
+
+**Testing strategy (report):** automated unit tests assert business rules in MO, Student, shared account, and servlet access-control layers; manual acceptance is documented in [docs/Acceptance_Test_Checklist.md](docs/Acceptance_Test_Checklist.md). **Techniques:** equivalence classes, boundary values, state-transition testing, role-access testing; data isolation via `System.setProperty("ta.data.dir", ...)`.
+
+Manual testing still required before final submission:
+
+- Browser-level Student flow: profile, attachments, job browsing, apply/withdraw, assigned jobs, notifications, and AI advisor UI fallback.
+- Browser-level Admin flow: demand review, workload levels, job drilldown, filtered exports, announcements, alerts, and account management.
+- Browser-level Shared account flow: password change success and validation failures from each role page.
+- Tomcat deployment smoke test using the generated WAR.
 
 ## Demo Accounts
 
@@ -76,9 +108,12 @@ Use the following accounts for demonstration:
 ## Current Version Notes
 
 - Sprint 1 release tag: `v1.0-sprint1`
-- Current repository state is `Sprint 3 development in progress`
-- Sprint 1 and Sprint 2 core workflows are already implemented and remain the current functional baseline
-- Sprint 3 work now focuses on workflow optimization, JSON data design, reporting, and final acceptance preparation
+- Sprint 2 release tag: `v2.0-sprint2`
+- Sprint 3 release tag: `v3.0-Sprint3`
+- Final documentation update: `2026-05-21`
+- Final assessment date from the project handout: `2026-05-24`
+- Current repository state is final delivery preparation with Sprint 1-4 features integrated on the active development branches.
+- Sprint 1 and Sprint 2 core workflows remain the functional baseline; Sprint 3 and Sprint 4 add reporting, account maintenance, workload visibility, demand review, AI-assisted matching/advice, announcements, and final acceptance readiness.
 
 ## Current Features
 
@@ -88,13 +123,14 @@ Use the following accounts for demonstration:
 - MO workflow for demand creation, approval tracking, job publishing, applicant review, hiring actions, and recruitment lifecycle control
 - Admin workflow for dashboard overview, workload monitoring, demand review, recruitment reopen, and user management
 
-## Sprint 3 Focus
+## Final Delivery Focus
 
 - Admin: workload threshold setting, weekly report export, and job filtering
 - Shared: self-service password change
 - MO: applicant review notes, posted-job history, and applicant export
 - TA: assigned jobs and schedule visibility
-- Non-functional: performance, loading-state polish, and acceptance-test preparation
+- Sprint 4: demand approval workbench, job-level application drilldown, recruitment outcome views, announcements, alerts, and AI-assisted student guidance
+- Non-functional: performance, loading-state polish, JavaDocs, automated tests, and acceptance-test preparation
 
 ## Runtime Data Storage
 
@@ -131,6 +167,7 @@ Initialization rules:
 
 - Sprint 3 minimal interface and data design: [docs/Sprint3_Minimal_Design.md](docs/Sprint3_Minimal_Design.md)
 - Acceptance checklist for hand test and demo rehearsal: [docs/Acceptance_Test_Checklist.md](docs/Acceptance_Test_Checklist.md)
+- JavaDocs and code documentation notes: [docs/JavaDocs.md](docs/JavaDocs.md)
 
 ## 1. Project Introduction 
 ### Project Overview
@@ -154,14 +191,14 @@ The current intermediate version includes:
 - expanded MO workflow for applicant review, hiring decisions, and job lifecycle control
 - expanded student workflow for profile persistence, attachments, and application management
 
-### Sprint 3 Development Status
-Sprint 3 extends the current baseline toward final delivery readiness.
+### Final Delivery Status
+The current version integrates the Sprint 1 to Sprint 4 workflows for final delivery preparation.
 
-The current Sprint 3 development scope includes:
-- documentation synchronization for runtime storage and interface planning
+The final delivery scope includes:
+- synchronized documentation for setup, runtime storage, API contracts, JavaDocs, and testing
 - single-location JSON persistence under `WEB-INF/data`
-- minimal interface and data design for the remaining Sprint 3 stories
-- acceptance test checklist preparation for final demo rehearsal and regression checking
+- automated MO service tests and manual acceptance checklist preparation
+- final UI and workflow polish for student, MO, and administrator portals
 
 ---
 

--- a/docs/Acceptance_Test_Checklist.md
+++ b/docs/Acceptance_Test_Checklist.md
@@ -1,6 +1,6 @@
 # Acceptance Test Checklist
 
-This checklist is prepared for Sprint 3 hand test, regression check, and final demo rehearsal.
+This checklist is prepared for Sprint 3/Sprint 4 hand test, regression check, and final demo rehearsal.
 
 Status fields to fill during execution:
 
@@ -34,7 +34,7 @@ Recommended evidence:
 | AUTH-01 | All Users | JSON files under `WEB-INF/data` contain the demo accounts. | 1. Open the login page.<br>2. Log in as Student using `student@demo.com / demo123`.<br>3. Repeat for Teacher and Admin accounts. | Each account is redirected to the correct role page. |  |  |
 | AUTH-02 | All Users | Login page is open. | 1. Submit an incorrect password.<br>2. Submit an empty login form. | The system shows an error and does not create a session. |  |  |
 | AUTH-03 | All Users | User is logged in. | 1. Click Logout.<br>2. Try reopening a protected page in the same browser tab. | Session is invalidated and the protected page is no longer accessible directly. |  |  |
-| AUTH-04 | Tester | No valid session for the target role. | 1. Request a protected URL such as `/pages/admin.jsp` or `/api/admin/dashboard` without a matching session. | Access is rejected or redirected according to the current auth filter behavior. |  |  |
+| AUTH-04 | Tester | No valid session for the target role. | 1. Request a protected URL such as `/pages/admin.jsp` or `/api/admin/dashboard` without a matching session.<br>2. Log in as a different role and request an admin, MO, or student API directly. | Unauthenticated API access returns unauthorized, and wrong-role API access returns forbidden or redirects according to the current auth filter behavior. |  |  |
 
 ---
 
@@ -57,6 +57,7 @@ Recommended evidence:
 | STU-03 | Student | Student has one active non-hired application. | 1. Withdraw that application from the application list. | The application disappears from the active list or is shown as no longer active according to the current UI behavior. |  |  |
 | STU-04 | Student | Student has at least one hired application. | 1. Open the assigned jobs / my jobs / schedule view.<br>2. Inspect the listed assignment. | Only hired jobs are displayed, with module, organiser, weekly hours, schedule, location, and deadline. |  |  |
 | STU-05 | Student | Student has no hired applications. | 1. Open the assigned jobs / schedule view. | The system shows a clear empty state instead of a broken table or blank page. |  |  |
+| STU-06 | Student | Student is logged in and AI advisor is available. | 1. Open the AI advisor panel.<br>2. Submit a normal request.<br>3. If external AI is not configured, verify fallback guidance appears. | The panel returns useful advice without breaking the page, even when external AI configuration is unavailable. |  |  |
 
 ---
 
@@ -104,7 +105,7 @@ Recommended rehearsal order:
 1. `ENV-01` to `ENV-04`
 2. `AUTH-01` to `AUTH-04`
 3. `PWD-01` to `PWD-03`
-4. `STU-01` to `STU-05`
+4. `STU-01` to `STU-06`
 5. `MO-01` to `MO-06`
 6. `ADM-01` to `ADM-05`
 7. `REG-01` to `REG-05`

--- a/docs/JavaDocs.md
+++ b/docs/JavaDocs.md
@@ -1,0 +1,67 @@
+# JavaDocs and Code Documentation
+
+This document summarizes the main Java packages and explains how to generate the JavaDoc HTML included in the final software evidence.
+
+## Generate JavaDocs
+
+Run from the repository root:
+
+```powershell
+mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" javadoc:javadoc
+```
+
+Generated documentation is written to:
+
+```text
+web/target/site/apidocs/index.html
+```
+
+The generated `target` directory is ignored by Git. For the final `Software_group59.zip`, generate the JavaDocs before packaging the software evidence if HTML JavaDocs are required.
+
+## Package Overview
+
+| Package | Responsibility |
+| --- | --- |
+| `com.ta.model` | Plain Java data models persisted to JSON files, such as users, students, jobs, applications, notifications, and hiring history. |
+| `com.ta.dto` | Request and response DTOs used by servlet endpoints. Subpackages separate `admin`, `mo`, `student`, and shared account contracts. |
+| `com.ta.service` | Business logic for account, admin, MO, and student workflows. Services read/write JSON data through `JsonUtility` and enforce role-specific rules. |
+| `com.ta.web` | Servlet controllers and role-specific base servlets. These classes map HTTP endpoints to service methods and return JSON responses or JSP navigation. |
+| `com.ta.util` | Shared infrastructure utilities for JSON persistence, file uploads, weekly-hour calculation, and response formatting support. |
+| `com.ta.constant` | Shared constants such as error codes. |
+
+## Main Service Areas
+
+- `AccountService` implements shared self-service password changes.
+- `AdminDashboardService`, `AdminDemandReviewService`, `AdminReportService`, `AdminUserService`, and related admin services implement dashboard monitoring, demand approval, reporting, backup, announcements, and user management.
+- `MoDemandService`, `MoJobService`, `MoApplicationService`, `MoHiringService`, and `MoNotificationService` implement Module Organiser demand, publishing, applicant review, hiring, and notification workflows.
+- `StudentService`, `JobMatchingService`, `SkillMatchScorer`, and AI advisor services implement student profile, job browsing, applications, assigned jobs, notifications, and recommendation support.
+
+## Endpoint Documentation Source
+
+Functional endpoint documentation is maintained in `Function_Details.md`. The implemented servlet mappings are the source of truth for final API verification:
+
+- Student APIs use `/api/student/*`.
+- MO APIs use `/api/mo/*`.
+- Admin APIs use `/api/admin/*`.
+- Shared account API uses `/api/account/change-password`.
+
+## Testing Documentation
+
+Automated service tests live under:
+
+```text
+web/src/test/java
+```
+
+The current automated tests cover:
+
+- MO applicant management, export, status filtering, status transitions, notes/feedback, and notifications.
+- Student profile persistence, attachment upload/delete, apply/withdraw, assigned jobs, and AI advisor fallback.
+- Shared password change success and validation failures.
+- Servlet access control for unauthenticated and wrong-role API access.
+
+Manual browser and Tomcat smoke acceptance testing remains documented in:
+
+```text
+docs/Acceptance_Test_Checklist.md
+```

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -61,6 +61,19 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <docencoding>${project.build.sourceEncoding}</docencoding>
+                    <charset>${project.build.sourceEncoding}</charset>
+                    <doclint>none</doclint>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/web/src/main/java/com/ta/service/mo/MoJobHistoryService.java
+++ b/web/src/main/java/com/ta/service/mo/MoJobHistoryService.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MoJobHistoryService {
 
@@ -36,7 +37,7 @@ public class MoJobHistoryService {
                     .filter(job -> moId.equals(job.getTeacherId()))
                     .map(job -> toHistoryItem(job, applicantCountByJobId, hireCountByJobId))
                     .sorted(Comparator.comparing(MoJobHistoryItemResponse::getReleaseTime, Comparator.nullsLast(String::compareTo)).reversed())
-                    .toList();
+                    .collect(Collectors.toList());
 
             MoJobHistoryResponse response = new MoJobHistoryResponse();
             response.setItems(items);

--- a/web/src/main/java/com/ta/web/AuthFilter.java
+++ b/web/src/main/java/com/ta/web/AuthFilter.java
@@ -79,7 +79,7 @@ public class AuthFilter extends HttpFilter implements Filter {
             return "admin".equals(normalizedRole);
         }
 
-        if ("/pages/student.jsp".equals(path)) {
+        if (path.startsWith("/api/student/") || "/pages/student.jsp".equals(path)) {
             return "student".equals(normalizedRole);
         }
 

--- a/web/src/test/java/com/ta/service/account/AccountServiceTest.java
+++ b/web/src/test/java/com/ta/service/account/AccountServiceTest.java
@@ -1,0 +1,97 @@
+package com.ta.service.account;
+
+import com.ta.constant.ErrorCodes;
+import com.ta.model.User;
+import com.ta.testsupport.MoTestSupport;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccountServiceTest extends MoTestSupport {
+
+    private AccountService service;
+
+    @BeforeEach
+    void seedUsers() throws Exception {
+        service = new AccountService();
+        writeUsers(List.of(
+                user("stu001", "student", "student@demo.test"),
+                user("mo001", "teacher", "teacher@demo.test"),
+                user("admin001", "admin", "admin@demo.test")
+        ));
+    }
+
+    @Test
+    void changePassword_studentTeacherAndAdmin_success() throws Exception {
+        assertTrue(service.changePassword(servletContext, "stu001", "oldPass1", "newPass1", "newPass1").isChanged());
+        assertTrue(service.changePassword(servletContext, "mo001", "oldPass1", "newPass2", "newPass2").isChanged());
+        assertTrue(service.changePassword(servletContext, "admin001", "oldPass1", "newPass3", "newPass3").isChanged());
+
+        assertEquals("newPass1", findUser("stu001").getPassword());
+        assertEquals("newPass2", findUser("mo001").getPassword());
+        assertEquals("newPass3", findUser("admin001").getPassword());
+    }
+
+    @Test
+    void changePassword_wrongOldPassword_rejected() {
+        AccountBusinessException ex = assertThrows(
+                AccountBusinessException.class,
+                () -> service.changePassword(servletContext, "stu001", "wrong", "newPass1", "newPass1")
+        );
+        assertEquals(ErrorCodes.VALIDATION_ERROR, ex.getCode());
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void changePassword_confirmMismatch_rejected() {
+        AccountBusinessException ex = assertThrows(
+                AccountBusinessException.class,
+                () -> service.changePassword(servletContext, "stu001", "oldPass1", "newPass1", "newPass2")
+        );
+        assertEquals(ErrorCodes.VALIDATION_ERROR, ex.getCode());
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void changePassword_newPasswordSameAsOld_rejected() {
+        AccountBusinessException ex = assertThrows(
+                AccountBusinessException.class,
+                () -> service.changePassword(servletContext, "stu001", "oldPass1", "oldPass1", "oldPass1")
+        );
+        assertEquals(ErrorCodes.VALIDATION_ERROR, ex.getCode());
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void changePassword_missingLogin_rejected401() {
+        AccountBusinessException ex = assertThrows(
+                AccountBusinessException.class,
+                () -> service.changePassword(servletContext, "", "oldPass1", "newPass1", "newPass1")
+        );
+        assertEquals(ErrorCodes.UNAUTHORIZED, ex.getCode());
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, ex.getHttpStatus());
+    }
+
+    private User findUser(String id) throws Exception {
+        return readUsers().stream()
+                .filter(user -> id.equals(user.getId()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private User user(String id, String role, String email) {
+        User user = new User();
+        user.setId(id);
+        user.setName(id);
+        user.setEmail(email);
+        user.setRole(role);
+        user.setPassword("oldPass1");
+        return user;
+    }
+}

--- a/web/src/test/java/com/ta/service/mo/MoApplicationServiceTest.java
+++ b/web/src/test/java/com/ta/service/mo/MoApplicationServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -63,7 +64,7 @@ class MoApplicationServiceTest extends MoTestSupport {
         MoApplicationListResponse response = service.listApplications(servletContext, MO_ID, null, null);
         List<String> ids = response.getItems().stream()
                 .map(MoApplicationListItemResponse::getApplicationId)
-                .toList();
+                .collect(Collectors.toList());
         assertEquals(5, ids.size());
         assertTrue(ids.contains("app_pending"));
         assertTrue(ids.contains("app_hired"));

--- a/web/src/test/java/com/ta/service/mo/MoNotificationServiceTest.java
+++ b/web/src/test/java/com/ta/service/mo/MoNotificationServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -108,7 +109,7 @@ class MoNotificationServiceTest extends MoTestSupport {
         MoNotificationListResponse response = service.list(servletContext, MO_ID);
         List<String> times = response.getItems().stream()
                 .map(MoNotificationItemResponse::getApplicationTime)
-                .toList();
+                .collect(Collectors.toList());
         for (int i = 0; i < times.size() - 1; i++) {
             assertTrue(times.get(i).compareTo(times.get(i + 1)) >= 0);
         }

--- a/web/src/test/java/com/ta/service/student/StudentServiceTest.java
+++ b/web/src/test/java/com/ta/service/student/StudentServiceTest.java
@@ -1,0 +1,232 @@
+package com.ta.service.student;
+
+import com.ta.constant.ErrorCodes;
+import com.ta.dto.student.AiAdvisorResponse;
+import com.ta.dto.student.StudentApplicationCreateRequest;
+import com.ta.dto.student.StudentAssignedJobItemResponse;
+import com.ta.dto.student.StudentProfileResponse;
+import com.ta.dto.student.StudentProfileUpdateRequest;
+import com.ta.model.ApplicationRecord;
+import com.ta.model.Attachment;
+import com.ta.model.JobPosting;
+import com.ta.model.StudentProfile;
+import com.ta.model.User;
+import com.ta.service.student.ai.AiAdvisorClient;
+import com.ta.testsupport.MoTestSupport;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class StudentServiceTest extends MoTestSupport {
+
+    private static final String STUDENT_ID = "student_demo";
+    private static final String TEACHER_ID = "teacher_demo";
+    private StudentService service;
+
+    @BeforeEach
+    void seedData() throws Exception {
+        service = new StudentService();
+        when(servletContext.getRealPath("/WEB-INF/uploads/students"))
+                .thenReturn(tempDataDir.resolve("uploads").toString());
+
+        User student = user(STUDENT_ID, "Demo Student", "student@demo.test", "student", "S1001");
+        User teacher = user(TEACHER_ID, "Demo Teacher", "teacher@demo.test", "teacher", "");
+        writeUsers(List.of(student, teacher));
+
+        StudentProfile profile = new StudentProfile();
+        profile.setUserId(STUDENT_ID);
+        profile.setStudentId("S1001");
+        profile.setName("Demo Student");
+        profile.setEmail("student@demo.test");
+        profile.setProgramme("MSc CS");
+        profile.setSkills("Java, Python");
+        profile.setExperience("Lab tutoring");
+        profile.setAttachments(new ArrayList<>(List.of(attachment("att_resume.pdf"))));
+        writeStudents(List.of(profile));
+
+        writeJobs(List.of(openJob("job_open"), openJob("job_hired")));
+        writeApplications(new ArrayList<>());
+        writeNotifications(new ArrayList<>());
+    }
+
+    @Test
+    void updateProfile_persistsStudentFields() throws Exception {
+        StudentProfileUpdateRequest request = new StudentProfileUpdateRequest();
+        request.setName("Updated Student");
+        request.setPhone("07700900001");
+        request.setSkills("Java, SQL");
+        request.setExperience("Two lab sessions");
+
+        StudentProfileResponse response = service.updateMyProfile(servletContext, STUDENT_ID, request);
+
+        assertEquals("Updated Student", response.getName());
+        assertEquals("07700900001", response.getPhone());
+        assertEquals("Java, SQL", response.getSkills());
+        assertEquals("Two lab sessions", response.getExperience());
+        assertEquals("Updated Student", readUsers().get(0).getName());
+        assertEquals("Java, SQL", readStudents().get(0).getSkills());
+    }
+
+    @Test
+    void updateProfile_invalidPhone_throws400() {
+        StudentProfileUpdateRequest request = new StudentProfileUpdateRequest();
+        request.setName("Demo Student");
+        request.setPhone("12345");
+
+        StudentBusinessException ex = assertThrows(
+                StudentBusinessException.class,
+                () -> service.updateMyProfile(servletContext, STUDENT_ID, request)
+        );
+        assertEquals(ErrorCodes.VALIDATION_ERROR, ex.getCode());
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void uploadAndDeleteAttachment_persistsMetadataAndFile() throws Exception {
+        Attachment uploaded = service.uploadAttachment(
+                servletContext,
+                STUDENT_ID,
+                new ByteArrayInputStream("%PDF-1.4".getBytes()),
+                8,
+                "resume.pdf",
+                "Resume"
+        );
+
+        assertEquals("resume.pdf", uploaded.getFileName());
+        assertTrue(Files.exists(tempDataDir.resolve("uploads")
+                .resolve("S1001")
+                .resolve("profile-attachments")
+                .resolve(uploaded.getId())));
+        assertTrue(readStudents().get(0).getAttachments().stream()
+                .anyMatch(a -> uploaded.getId().equals(a.getId())));
+
+        service.deleteAttachment(servletContext, STUDENT_ID, uploaded.getId());
+
+        assertFalse(Files.exists(tempDataDir.resolve("uploads")
+                .resolve("S1001")
+                .resolve("profile-attachments")
+                .resolve(uploaded.getId())));
+        assertTrue(readStudents().get(0).getAttachments().stream()
+                .noneMatch(a -> uploaded.getId().equals(a.getId())));
+    }
+
+    @Test
+    void applyAndWithdraw_createsAndRemovesApplicationWithNotifications() throws Exception {
+        StudentApplicationCreateRequest request = new StudentApplicationCreateRequest();
+        request.setJobId("job_open");
+        request.setSelectedAttachmentIds(List.of("att_resume.pdf"));
+
+        String applicationId = service.applyForJob(servletContext, STUDENT_ID, request).getId();
+
+        assertEquals(1, readApplications().size());
+        assertEquals("pending", readApplications().get(0).getStatus());
+        assertEquals(List.of("att_resume.pdf"), readApplications().get(0).getSelectedAttachmentIds());
+        assertTrue(readNotifications().stream().anyMatch(n -> applicationId.equals(n.getApplicationId())));
+
+        service.withdrawApplication(servletContext, STUDENT_ID, applicationId);
+
+        assertTrue(readApplications().isEmpty());
+        assertTrue(readNotifications().stream().anyMatch(n -> ("noti_withdraw_" + applicationId).equals(n.getId())));
+    }
+
+    @Test
+    void apply_duplicateActiveApplication_throws400() {
+        StudentApplicationCreateRequest request = new StudentApplicationCreateRequest();
+        request.setJobId("job_open");
+        request.setSelectedAttachmentIds(List.of("att_resume.pdf"));
+        service.applyForJob(servletContext, STUDENT_ID, request);
+
+        StudentBusinessException ex = assertThrows(
+                StudentBusinessException.class,
+                () -> service.applyForJob(servletContext, STUDENT_ID, request)
+        );
+        assertEquals(ErrorCodes.VALIDATION_ERROR, ex.getCode());
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getHttpStatus());
+    }
+
+    @Test
+    void assignedJobs_returnsOnlyActiveHiredJobsWithScheduleDetails() throws Exception {
+        ApplicationRecord hired = application("app_hired_student", "job_hired", "hired", true);
+        hired.setStudentId(STUDENT_ID);
+        ApplicationRecord pending = application("app_pending_student", "job_open", "pending", true);
+        pending.setStudentId(STUDENT_ID);
+        writeApplications(List.of(hired, pending));
+
+        List<StudentAssignedJobItemResponse> items = service.listMyAssignedJobs(servletContext, STUDENT_ID).getItems();
+
+        assertEquals(1, items.size());
+        StudentAssignedJobItemResponse item = items.get(0);
+        assertEquals("job_hired", item.getJobId());
+        assertEquals(10, item.getWeeklyHours());
+        assertEquals("Mon 10:00-12:00", item.getSchedule());
+        assertEquals("Room 101", item.getLocation());
+        assertEquals("2026-05-24", item.getDeadline());
+    }
+
+    @Test
+    void aiAdvisor_usesFallbackWhenExternalClientUnavailable() {
+        AiAdvisorService advisor = new AiAdvisorService(
+                new JobMatchingService(),
+                new SkillExtractionService(),
+                new AiAdvisorClient()
+        );
+
+        AiAdvisorResponse response = advisor.advise(servletContext, STUDENT_ID, "Which job fits me?");
+
+        assertTrue(response.isFallback());
+        assertTrue(response.getAnswer().contains("Based on the current matching results"));
+    }
+
+    private User user(String id, String name, String email, String role, String studentNumber) {
+        User user = new User();
+        user.setId(id);
+        user.setName(name);
+        user.setEmail(email);
+        user.setPassword("oldPass1");
+        user.setRole(role);
+        user.setStudentId(studentNumber);
+        user.setProgramme("MSc CS");
+        return user;
+    }
+
+    private JobPosting openJob(String id) {
+        JobPosting job = new JobPosting();
+        job.setId(id);
+        job.setTeacherId(TEACHER_ID);
+        job.setTeacherName("Demo Teacher");
+        job.setModuleCode("EBU6304");
+        job.setTitle("Software Engineering TA");
+        job.setStatus("open");
+        job.setPublished(true);
+        job.setWithdrawn(false);
+        job.setHours(10);
+        job.setPositions(2);
+        job.setSchedule("Mon 10:00-12:00");
+        job.setLocation("Room 101");
+        job.setDeadline("2026-05-24");
+        job.setRequirements("Java, Python");
+        return job;
+    }
+
+    private Attachment attachment(String id) {
+        Attachment attachment = new Attachment();
+        attachment.setId(id);
+        attachment.setFileName("resume.pdf");
+        attachment.setFileType("pdf");
+        attachment.setLabel("Resume");
+        attachment.setFileSize(10);
+        attachment.setUploadedAt("2026-05-21T00:00:00Z");
+        return attachment;
+    }
+}

--- a/web/src/test/java/com/ta/testsupport/MoTestSupport.java
+++ b/web/src/test/java/com/ta/testsupport/MoTestSupport.java
@@ -4,6 +4,7 @@ import com.ta.model.ApplicationRecord;
 import com.ta.model.JobPosting;
 import com.ta.model.NotificationRecord;
 import com.ta.model.StudentProfile;
+import com.ta.model.User;
 import com.ta.service.mo.MoBusinessException;
 import com.ta.util.JsonUtility;
 import jakarta.servlet.ServletContext;
@@ -32,7 +33,7 @@ public abstract class MoTestSupport {
     public static final String STUDENT_USER_ID = "student_test_1";
 
     @TempDir
-    Path tempDataDir;
+    protected Path tempDataDir;
 
     protected ServletContext servletContext;
 
@@ -63,12 +64,24 @@ public abstract class MoTestSupport {
         JsonUtility.saveStudents(servletContext, students);
     }
 
+    protected void writeUsers(List<User> users) throws IOException {
+        JsonUtility.saveUsers(servletContext, users);
+    }
+
     protected List<ApplicationRecord> readApplications() throws IOException {
         return JsonUtility.loadApplications(servletContext);
     }
 
     protected List<NotificationRecord> readNotifications() throws IOException {
         return JsonUtility.loadNotifications(servletContext);
+    }
+
+    protected List<StudentProfile> readStudents() throws IOException {
+        return JsonUtility.loadStudents(servletContext);
+    }
+
+    protected List<User> readUsers() throws IOException {
+        return JsonUtility.loadUsers(servletContext);
     }
 
     protected static void assertMoBusinessException(Runnable action, String expectedCode, int expectedHttpStatus) {

--- a/web/src/test/java/com/ta/web/AuthFilterTest.java
+++ b/web/src/test/java/com/ta/web/AuthFilterTest.java
@@ -1,0 +1,117 @@
+package com.ta.web;
+
+import com.ta.model.SessionUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthFilterTest {
+
+    private AuthFilter filter;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new AuthFilter();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        when(request.getContextPath()).thenReturn("/web");
+    }
+
+    @Test
+    void apiWithoutLogin_returns401() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/admin/dashboard");
+        when(request.getSession(false)).thenReturn(null);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Login required");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void wrongRoleForAdminApi_returns403() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/admin/dashboard");
+        HttpSession session = session("student");
+        when(request.getSession(false)).thenReturn(session);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void wrongRoleForMoApi_returns403() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/mo/applications");
+        HttpSession session = session("student");
+        when(request.getSession(false)).thenReturn(session);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void wrongRoleForStudentApi_returns403() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/student/profile");
+        HttpSession session = session("teacher");
+        when(request.getSession(false)).thenReturn(session);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void studentPageRequiresStudentRole() throws Exception {
+        when(request.getServletPath()).thenReturn("/pages/student.jsp");
+        HttpSession session = session("teacher");
+        when(request.getSession(false)).thenReturn(session);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendRedirect("/web/pages/teacher.jsp");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void correctAdminRole_allowsAdminApi() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/admin/dashboard");
+        HttpSession session = session("admin");
+        when(request.getSession(false)).thenReturn(session);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void publicLoginPage_allowsWithoutSession() throws Exception {
+        when(request.getServletPath()).thenReturn("/pages/login.jsp");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    private HttpSession session(String role) {
+        HttpSession session = mock(HttpSession.class);
+        when(session.getAttribute("currentUser"))
+                .thenReturn(new SessionUser(role + "_id", "Name", role + "@demo.test", role));
+        return session;
+    }
+}


### PR DESCRIPTION
## Summary
- Added final-readiness documentation for JavaDocs, testing, setup, and acceptance checks.
- Expanded automated test coverage for Student workflows, shared password change, and servlet access control.
- Fixed student API access control so `/api/student/*` requires a student session.
- Kept Java 11 compatibility for stream collection usage.

## Changes
- Added `StudentServiceTest` for profile persistence, attachments, apply/withdraw, assigned jobs, and AI advisor fallback.
- Added `AccountServiceTest` for password change success and validation failures across roles.
- Added `AuthFilterTest` for unauthenticated and wrong-role API access.
- Updated README, JavaDocs notes, and acceptance checklist.
- Added Maven JavaDocs plugin configuration.

## Verification
- `mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" test`
  - 80 tests passed.
- `mvn -f web/pom.xml "-Dmaven.repo.local=.m2repo" javadoc:javadoc`
  - BUILD SUCCESS.
- `node --check` passed for admin, student, teacher, and MO JavaScript files.

## Notes
- `.m2repo/` and the local abnormal untracked file are intentionally not included.
- Browser-level Tomcat smoke testing is still manual evidence for final submission.